### PR TITLE
Initial project skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/library/golang:1.19.4-alpine3.17 as builder
+WORKDIR /go/src/github.com/kiagnose/kubevirt-rt-checkup
+COPY . .
+RUN go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1.0-1656.1669627757
+
+RUN microdnf install -y shadow-utils && \
+    adduser --system --no-create-home -u 900 rt-checkup && \
+    microdnf remove -y shadow-utils && \
+    microdnf clean all
+
+COPY --from=builder /go/src/github.com/kiagnose/kubevirt-rt-checkup/bin/kubevirt-rt-checkup /usr/local/bin
+
+USER 900
+
+ENTRYPOINT ["kubevirt-rt-checkup"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("kubevirt-rt-checkup starting...")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kiagnose/kubevirt-rt-checkup
+
+go 1.19


### PR DESCRIPTION
Add the following files:
- `go.mod`
- `main.go`
- `Dockerfile`

The project could be built using the following command:
```bash
podman build . -t quay.io/kiagnose/kubevirt-rt-checkup:devel
```

The project could be locally executed using the following command:
```bash
podman run --rm quay.io/kiagnose/kubevirt-rt-checkup:devel
```