### PR TITLE
Initial automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/bin
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
-FROM docker.io/library/golang:1.19.4-alpine3.17 as builder
-WORKDIR /go/src/github.com/kiagnose/kubevirt-rt-checkup
-COPY . .
-RUN go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1.0-1656.1669627757
 
 RUN microdnf install -y shadow-utils && \
@@ -10,7 +5,7 @@ RUN microdnf install -y shadow-utils && \
     microdnf remove -y shadow-utils && \
     microdnf clean all
 
-COPY --from=builder /go/src/github.com/kiagnose/kubevirt-rt-checkup/bin/kubevirt-rt-checkup /usr/local/bin
+COPY ./bin/kubevirt-rt-checkup /usr/local/bin
 
 USER 900
 

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,7 @@ build:
 	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
 	$(CONTAINER_ENGINE) build . -t $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build
+
+unit-test:
+	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go test -v ./...
+.PHONY: unit-test

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ CHECKUP_IMAGE_TAG ?= devel
 GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.19.4-alpine3.17
 
+LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
+LINTER_IMAGE_TAG := v1.50.1
+
 PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-rt-checkup
 
 build:
@@ -16,3 +19,7 @@ build:
 unit-test:
 	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go test -v ./...
 .PHONY: unit-test
+
+lint:
+	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) golangci-lint run -v
+.PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ LINTER_IMAGE_TAG := v1.50.1
 
 PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-rt-checkup
 
+all: lint unit-test build
+.PHONY: all
+
 build:
 	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
 	$(CONTAINER_ENGINE) build . -t $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+CONTAINER_ENGINE ?= podman
+
+CHECKUP_IMAGE_NAME := quay.io/kiagnose/kubevirt-rt-checkup
+CHECKUP_IMAGE_TAG ?= devel
+
+GO_IMAGE_NAME := docker.io/library/golang
+GO_IMAGE_TAG := 1.19.4-alpine3.17
+
+PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-rt-checkup
+
+build:
+	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
+	$(CONTAINER_ENGINE) build . -t $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
+.PHONY: build


### PR DESCRIPTION
Add automation for:
- Building the checkup's binary and image
- Unit testing the checkup
- Linting the checkup

To run all targets:
```bash
make
```

To build the checkup image:
```bash
make build
```

To unit test the code:
```bash
make unit-test
```

To lint the code:
```bash
make lint
```

~~Depends on PR #1.~~