### PR TITLE
GitHub actions: Add publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      CONTAINER_ENGINE: podman
+      CHECKUP_IMAGE_TAG: ${{github.ref_name}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Login to quay.io
+        run:
+          ${CONTAINER_ENGINE} login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Build and push image
+        run: make push

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CONTAINER_ENGINE ?= podman
 
-CHECKUP_IMAGE_NAME := quay.io/kiagnose/kubevirt-rt-checkup
+CHECKUP_IMAGE_NAME ?= quay.io/kiagnose/kubevirt-rt-checkup
 CHECKUP_IMAGE_TAG ?= devel
 
 GO_IMAGE_NAME := docker.io/library/golang
@@ -26,3 +26,7 @@ unit-test:
 lint:
 	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) golangci-lint run -v
 .PHONY: lint
+
+push: build
+	$(CONTAINER_ENGINE) push $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
+.PHONY: push


### PR DESCRIPTION
Add the publish workflow, in order to push the
checkup's image to `quay.io/kiagnose/kubevirt-rt-checkup:<tag>`.

The `push` target was tested against my private `quay.io` account.
The push github actions workflow will be tested upon the merge of this PR.

This PR depends on PR #3.