### PR TITLE
Makefile: Make the push target independent

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,5 +22,7 @@ jobs:
       - name: Login to quay.io
         run:
           ${CONTAINER_ENGINE} login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
-      - name: Build and push image
+      - name: Build the image
+        run: make build
+      - name: Push the image
         run: make push

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ lint:
 	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) golangci-lint run -v --timeout=3m ./cmd/... ./pkg/...
 .PHONY: lint
 
-push: build
+push:
 	$(CONTAINER_ENGINE) push $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: push


### PR DESCRIPTION
Currently, the `push` target is dependent on the `build` target.
In order to meet the need to push an existing image, make the push target independent.

Signed-off-by: Orel Misan <omisan@redhat.com>