### PR TITLE
GitHub Actions: Rename the Lint job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
Capitalize the `lint` job name in order to align it with the other jobs.

Signed-off-by: Orel Misan <omisan@redhat.com>