### PR TITLE
Project skeleton

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package checkup
+
+import (
+	"context"
+
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+)
+
+type Checkup struct {
+}
+
+func New() *Checkup {
+	return &Checkup{}
+}
+
+func (c *Checkup) Setup(ctx context.Context) error {
+	return nil
+}
+
+func (c *Checkup) Run(ctx context.Context) error {
+	return nil
+}
+
+func (c *Checkup) Teardown(ctx context.Context) error {
+	return nil
+}
+
+func (c *Checkup) Results() status.Results {
+	return status.Results{}
+}

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package checkup_test
+
+import (
+	"context"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup"
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+)
+
+func TestCheckupShouldSucceed(t *testing.T) {
+	testCheckup := checkup.New()
+
+	assert.NoError(t, testCheckup.Setup(context.Background()))
+	assert.NoError(t, testCheckup.Run(context.Background()))
+	assert.NoError(t, testCheckup.Teardown(context.Background()))
+
+	actualResults := testCheckup.Results()
+	expectedResults := status.Results{}
+
+	assert.Equal(t, expectedResults, actualResults)
+}

--- a/pkg/internal/launcher/launcher.go
+++ b/pkg/internal/launcher/launcher.go
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package launcher
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+)
+
+type checkup interface {
+	Setup(ctx context.Context) error
+	Run(ctx context.Context) error
+	Teardown(ctx context.Context) error
+	Results() status.Results
+}
+
+type reporter interface {
+	Report(status.Status) error
+}
+
+type Launcher struct {
+	checkup  checkup
+	reporter reporter
+}
+
+func New(checkup checkup, reporter reporter) Launcher {
+	return Launcher{
+		checkup:  checkup,
+		reporter: reporter,
+	}
+}
+
+func (l Launcher) Run(ctx context.Context) (runErr error) {
+	var runStatus status.Status
+	runStatus.StartTimestamp = time.Now()
+
+	if err := l.reporter.Report(runStatus); err != nil {
+		return err
+	}
+
+	defer func() {
+		runStatus.CompletionTimestamp = time.Now()
+		runStatus.Results = l.checkup.Results()
+		if err := l.reporter.Report(runStatus); err != nil {
+			runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
+		}
+		runErr = failureReason(runStatus)
+	}()
+
+	if err := l.checkup.Setup(ctx); err != nil {
+		runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
+		return err
+	}
+
+	defer func() {
+		if err := l.checkup.Teardown(ctx); err != nil {
+			runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
+		}
+	}()
+
+	if err := l.checkup.Run(ctx); err != nil {
+		runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func failureReason(sts status.Status) error {
+	if len(sts.FailureReason) > 0 {
+		return errors.New(strings.Join(sts.FailureReason, ", "))
+	}
+	return nil
+}

--- a/pkg/internal/launcher/launcher_test.go
+++ b/pkg/internal/launcher/launcher_test.go
@@ -1,0 +1,147 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package launcher_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/launcher"
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+)
+
+var (
+	errReport   = errors.New("report error")
+	errSetup    = errors.New("setup error")
+	errRun      = errors.New("run error")
+	errTeardown = errors.New("teardown error")
+)
+
+func TestLauncherRunShouldSucceed(t *testing.T) {
+	testLauncher := launcher.New(checkupStub{}, &reporterStub{})
+	assert.NoError(t, testLauncher.Run(context.Background()))
+}
+
+func TestLauncherRunShouldFailWhen(t *testing.T) {
+	t.Run("report fails", func(t *testing.T) {
+		testLauncher := launcher.New(checkupStub{}, &reporterStub{failReport: errReport})
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errReport.Error())
+	})
+
+	t.Run("setup fails", func(t *testing.T) {
+		testLauncher := launcher.New(checkupStub{failSetup: errSetup}, &reporterStub{})
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errSetup.Error())
+	})
+
+	t.Run("setup and 2nd report fail", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{failSetup: errSetup},
+			&reporterStub{failReport: errReport, failOnSecondReport: true},
+		)
+		err := testLauncher.Run(context.Background())
+		assert.ErrorContains(t, err, errSetup.Error())
+		assert.ErrorContains(t, err, errReport.Error())
+	})
+
+	t.Run("run fails", func(t *testing.T) {
+		testLauncher := launcher.New(checkupStub{failRun: errRun}, &reporterStub{})
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errRun.Error())
+	})
+
+	t.Run("teardown fails", func(t *testing.T) {
+		testLauncher := launcher.New(checkupStub{failTeardown: errTeardown}, &reporterStub{})
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errTeardown.Error())
+	})
+
+	t.Run("run and report fail", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{failRun: errRun},
+			&reporterStub{failReport: errReport, failOnSecondReport: true},
+		)
+		err := testLauncher.Run(context.Background())
+		assert.ErrorContains(t, err, errRun.Error())
+		assert.ErrorContains(t, err, errReport.Error())
+	})
+
+	t.Run("teardown and report fail", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{failTeardown: errTeardown},
+			&reporterStub{failReport: errReport, failOnSecondReport: true},
+		)
+		err := testLauncher.Run(context.Background())
+		assert.ErrorContains(t, err, errTeardown.Error())
+		assert.ErrorContains(t, err, errReport.Error())
+	})
+
+	t.Run("run, teardown and report fail", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{failRun: errRun, failTeardown: errTeardown},
+			&reporterStub{failReport: errReport, failOnSecondReport: true},
+		)
+		err := testLauncher.Run(context.Background())
+		assert.ErrorContains(t, err, errRun.Error())
+		assert.ErrorContains(t, err, errTeardown.Error())
+		assert.ErrorContains(t, err, errReport.Error())
+	})
+}
+
+type checkupStub struct {
+	failSetup    error
+	failRun      error
+	failTeardown error
+}
+
+func (cs checkupStub) Setup(_ context.Context) error {
+	return cs.failSetup
+}
+
+func (cs checkupStub) Run(_ context.Context) error {
+	return cs.failRun
+}
+
+func (cs checkupStub) Teardown(_ context.Context) error {
+	return cs.failTeardown
+}
+
+func (cs checkupStub) Results() status.Results {
+	return status.Results{}
+}
+
+type reporterStub struct {
+	reportCalls int
+	failReport  error
+	// The launcher calls the report twice: To mark the start timestamp and
+	// then to update the checkup results.
+	// Use this flag to cause the second report to fail.
+	failOnSecondReport bool
+}
+
+func (rs *reporterStub) Report(_ status.Status) error {
+	rs.reportCalls++
+	if rs.failOnSecondReport && rs.reportCalls == 2 {
+		return rs.failReport
+	} else if !rs.failOnSecondReport {
+		return rs.failReport
+	}
+	return nil
+}

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package reporter
+
+import "github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+
+type Reporter struct {
+}
+
+func New() *Reporter {
+	return &Reporter{}
+}
+
+func (r *Reporter) Report(checkupStatus status.Status) error {
+	return nil
+}

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package reporter_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/reporter"
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+)
+
+func TestReportShouldSucceed(t *testing.T) {
+	testReporter := reporter.New()
+
+	assert.NoError(t, testReporter.Report(status.Status{}))
+}

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package status
+
+import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
+
+type Results struct {
+}
+
+type Status struct {
+	kstatus.Status
+	Results
+}

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -20,12 +20,16 @@
 package pkg
 
 import (
+	"context"
 	"log"
 
 	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
 
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup"
 	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/client"
 	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/config"
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/launcher"
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/reporter"
 )
 
 func Run(rawEnv map[string]string) error {
@@ -46,7 +50,9 @@ func Run(rawEnv map[string]string) error {
 
 	printConfig(cfg)
 
-	return nil
+	l := launcher.New(checkup.New(), reporter.New())
+
+	return l.Run(context.Background())
 }
 
 func printConfig(checkupConfig config.Config) {

--- a/vendor/github.com/kiagnose/kiagnose/kiagnose/status/status.go
+++ b/vendor/github.com/kiagnose/kiagnose/kiagnose/status/status.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package status
+
+import "time"
+
+type Status struct {
+	Succeeded           bool
+	FailureReason       []string
+	Results             map[string]string
+	StartTimestamp      time.Time
+	CompletionTimestamp time.Time
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,6 +68,7 @@ github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8
 github.com/kiagnose/kiagnose/kiagnose/config
 github.com/kiagnose/kiagnose/kiagnose/configmap
 github.com/kiagnose/kiagnose/kiagnose/environment
+github.com/kiagnose/kiagnose/kiagnose/status
 github.com/kiagnose/kiagnose/kiagnose/types
 # github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 ## explicit; go 1.15


### PR DESCRIPTION
Introduce the project's skeleton, comprised of the following packages:
- status
- launcher
- checkup
- reporter

They are based on the VM latency checkup's packages with the same name[1].

Manually tested on an OpenShift 4.11 cluster.

[1] https://github.com/kiagnose/kiagnose/tree/95d8c7995fabbb7be11f7cde0eca57dc01e222bb/checkups/kubevirt-vm-latency/vmlatency/internal/