### PR TITLE
Makefile: Add cache to build, unit-test and lint targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+go-cache
 linter-cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+linter-cache

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+go-cache
 linter-cache

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+linter-cache

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ build:
 .PHONY: build
 
 unit-test:
-	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go test -v ./cmd/... ./pkg/...
+	$(CONTAINER_ENGINE) run --rm \
+		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
+		--workdir $(PROJECT_WORKING_DIR) \
+		$(GO_IMAGE_NAME):$(GO_IMAGE_TAG) \
+		go test -v ./cmd/... ./pkg/...
 .PHONY: unit-test
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,12 @@ all: lint unit-test build
 .PHONY: all
 
 build:
-	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
+	$(CONTAINER_ENGINE) run --rm \
+		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
+		--workdir $(PROJECT_WORKING_DIR) \
+		$(GO_IMAGE_NAME):$(GO_IMAGE_TAG) \
+		go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
+
 	$(CONTAINER_ENGINE) build . -t $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ unit-test:
 .PHONY: unit-test
 
 lint:
-	$(CONTAINER_ENGINE) run --rm -v $(PWD):$(PROJECT_WORKING_DIR):Z --workdir $(PROJECT_WORKING_DIR) $(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) golangci-lint run -v --timeout=3m ./cmd/... ./pkg/...
+	$(CONTAINER_ENGINE) run --rm \
+		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
+		--workdir $(PROJECT_WORKING_DIR) \
+		$(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) \
+		golangci-lint run -v --timeout=3m ./cmd/... ./pkg/...
 .PHONY: lint
 
 push:

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,11 @@ unit-test:
 .PHONY: unit-test
 
 lint:
+	mkdir -p $(PWD)/linter-cache
+
 	$(CONTAINER_ENGINE) run --rm \
 		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
+		-v $(PWD)/linter-cache:/root/.cache:Z \
 		--workdir $(PROJECT_WORKING_DIR) \
 		$(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) \
 		golangci-lint run -v --timeout=3m ./cmd/... ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ all: lint unit-test build
 .PHONY: all
 
 build:
+	mkdir -p $(PWD)/go-cache
+
 	$(CONTAINER_ENGINE) run --rm \
 		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
+		-v $(PWD)/go-cache:/root/.cache/go-build:Z \
 		--workdir $(PROJECT_WORKING_DIR) \
 		$(GO_IMAGE_NAME):$(GO_IMAGE_TAG) \
 		go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
@@ -25,8 +28,11 @@ build:
 .PHONY: build
 
 unit-test:
+	mkdir -p $(PWD)/go-cache
+
 	$(CONTAINER_ENGINE) run --rm \
 		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
+		-v $(PWD)/go-cache:/root/.cache/go-build:Z \
 		--workdir $(PROJECT_WORKING_DIR) \
 		$(GO_IMAGE_NAME):$(GO_IMAGE_TAG) \
 		go test -v ./cmd/... ./pkg/...


### PR DESCRIPTION
Currently, it takes several minutes for the lint, unit-test and build targets to complete locally.
Add a cache directory for the lint target, and another one for the unit-test and build targets.
The addition of cache speeds up the build process.