### PR TITLE
github actions: Add a job to check go mod tidy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  go-mod-tidy:
+    name: Go mod tidy check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: katexochen/go-tidy-check@v1
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Check that `go mod tidy` does not change files on the project:
- go.mod
- go.sum

It will guard against commits that do not update their new dependencies.

Based on https://github.com/kiagnose/kiagnose/pull/213

Signed-off-by: Orel Misan <omisan@redhat.com>