### PR TITLE
e2e, checkup Job: Always pull the latest checkup image

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -209,6 +209,7 @@ func newCheckupJob() *batchv1.Job {
 						{
 							Name:            "rt-checkup",
 							Image:           testImageName,
+							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: newSecurityContext(),
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
Currently, the image pull policy is set to the default "IfNotPresent" - which does not pull the latest checkup image.

In order to always test the latest checkup image,
change the image pull policy to "Always".

Signed-off-by: Orel Misan <omisan@redhat.com>