### PR TITLE
checkup: Add VirtualMachineInstance creation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,12 @@ func main() {
 
 	const errMessagePrefix = "kubevirt-rt-checkup failed"
 
-	if err := pkg.Run(rawEnv); err != nil {
+	namespace, err := environment.ReadNamespaceFile()
+	if err != nil {
+		log.Fatalf("%s: %v\n", errMessagePrefix, err)
+	}
+
+	if err = pkg.Run(rawEnv, namespace); err != nil {
 		log.Fatalf("%s: %v\n", errMessagePrefix, err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v12.0.0+incompatible
+	kubevirt.io/api v0.0.0-20221013011232-17665f214e18
 	kubevirt.io/client-go v0.58.0
 )
 
@@ -57,7 +58,6 @@ require (
 	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
-	kubevirt.io/api v0.0.0-20221013011232-17665f214e18 // indirect
 	kubevirt.io/containerized-data-importer-api v1.50.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -21,16 +21,29 @@ package checkup_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	assert "github.com/stretchr/testify/require"
 
+	kvcorev1 "kubevirt.io/api/core/v1"
+
 	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup"
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
 )
 
+const (
+	testNamespace      = "target-ns"
+	testTargetNodeName = "my-node"
+	testPVCName        = "my-rt-vm-pvc"
+)
+
 func TestCheckupShouldSucceed(t *testing.T) {
-	testCheckup := checkup.New()
+	testClient := newClientStub()
+	testCheckup := checkup.New(testClient, testNamespace, newTestConfig())
 
 	assert.NoError(t, testCheckup.Setup(context.Background()))
 	assert.NoError(t, testCheckup.Run(context.Background()))
@@ -40,4 +53,52 @@ func TestCheckupShouldSucceed(t *testing.T) {
 	expectedResults := status.Results{}
 
 	assert.Equal(t, expectedResults, actualResults)
+}
+
+func TestSetupShouldFail(t *testing.T) {
+	t.Run("when VMI creation fails", func(t *testing.T) {
+		expectedVMICreationFailure := errors.New("failed to create VMI")
+
+		testClient := newClientStub()
+		testClient.vmiCreationFailure = expectedVMICreationFailure
+		testCheckup := checkup.New(testClient, testNamespace, newTestConfig())
+
+		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedVMICreationFailure.Error())
+	})
+}
+
+type clientStub struct {
+	createdVMIs        map[string]*kvcorev1.VirtualMachineInstance
+	vmiCreationFailure error
+}
+
+func newClientStub() *clientStub {
+	return &clientStub{
+		createdVMIs: map[string]*kvcorev1.VirtualMachineInstance{},
+	}
+}
+
+func (cs *clientStub) CreateVirtualMachineInstance(_ context.Context,
+	namespace string,
+	vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
+	if cs.vmiCreationFailure != nil {
+		return nil, cs.vmiCreationFailure
+	}
+
+	vmiFullName := fmt.Sprintf("%s/%s", namespace, vmi.Name)
+	cs.createdVMIs[vmiFullName] = vmi
+
+	return vmi, nil
+}
+
+func newTestConfig() config.Config {
+	return config.Config{
+		PodName:                      "",
+		PodUID:                       "",
+		TargetNode:                   testTargetNodeName,
+		GuestImageSourcePVCNamespace: testNamespace,
+		GuestImageSourcePVCName:      testPVCName,
+		OslatDuration:                10 * time.Minute,
+		OslatLatencyThreshold:        45 * time.Microsecond,
+	}
 }

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -1,0 +1,234 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vmi
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+)
+
+// Based on annotation names from:
+// https://github.com/cri-o/cri-o/blob/fa0fa5de1c17ddd7b6fcdbc030b6b571ce37e643/pkg/annotations/annotations.go
+const (
+	// CRIOCPULoadBalancingAnnotation indicates that load balancing should be disabled for CPUs used by the container
+	CRIOCPULoadBalancingAnnotation = "cpu-load-balancing.crio.io"
+
+	// CRIOCPUQuotaAnnotation indicates that CPU quota should be disabled for CPUs used by the container
+	CRIOCPUQuotaAnnotation = "cpu-quota.crio.io"
+
+	// CRIOIRQLoadBalancingAnnotation indicates that IRQ load balancing should be disabled for CPUs used by the container
+	CRIOIRQLoadBalancingAnnotation = "irq-load-balancing.crio.io"
+)
+
+const Disable = "disable"
+
+type Option func(vmi *kvcorev1.VirtualMachineInstance)
+
+func New(name string, options ...Option) *kvcorev1.VirtualMachineInstance {
+	newVMI := &kvcorev1.VirtualMachineInstance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kvcorev1.VirtualMachineInstanceGroupVersionKind.Kind,
+			APIVersion: kvcorev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	for _, f := range options {
+		f(newVMI)
+	}
+
+	return newVMI
+}
+
+func WithOwnerReference(ownerName, ownerUID string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if ownerUID != "" && ownerName != "" {
+			vmi.ObjectMeta.OwnerReferences = append(vmi.ObjectMeta.OwnerReferences, metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       ownerName,
+				UID:        types.UID(ownerUID),
+			})
+		}
+	}
+}
+
+func WithoutCRIOCPULoadBalancing() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.ObjectMeta.Annotations == nil {
+			vmi.ObjectMeta.Annotations = map[string]string{}
+		}
+
+		vmi.ObjectMeta.Annotations[CRIOCPULoadBalancingAnnotation] = Disable
+	}
+}
+
+func WithoutCRIOCPUQuota() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.ObjectMeta.Annotations == nil {
+			vmi.ObjectMeta.Annotations = map[string]string{}
+		}
+
+		vmi.ObjectMeta.Annotations[CRIOCPUQuotaAnnotation] = Disable
+	}
+}
+
+func WithoutCRIOIRQLoadBalancing() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.ObjectMeta.Annotations == nil {
+			vmi.ObjectMeta.Annotations = map[string]string{}
+		}
+
+		vmi.ObjectMeta.Annotations[CRIOIRQLoadBalancingAnnotation] = Disable
+	}
+}
+
+func WithRealtimeCPU() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.CPU = &kvcorev1.CPU{
+			Model:                 "host-passthrough",
+			DedicatedCPUPlacement: true,
+			IsolateEmulatorThread: true,
+
+			Features: []kvcorev1.CPUFeature{
+				{Name: "tsc-deadline", Policy: "require"},
+			},
+			NUMA: &kvcorev1.NUMA{
+				GuestMappingPassthrough: &kvcorev1.NUMAGuestMappingPassthrough{},
+			},
+			Realtime: &kvcorev1.Realtime{Mask: "1-2"},
+		}
+	}
+}
+
+func WithoutAutoAttachGraphicsDevice() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = Pointer(false)
+	}
+}
+
+func WithoutAutoAttachMemBalloon() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.AutoattachMemBalloon = Pointer(false)
+	}
+}
+
+func WithAutoAttachSerialConsole() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.AutoattachSerialConsole = Pointer(true)
+	}
+}
+
+func WithVirtIODisk(name string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, kvcorev1.Disk{
+			Name: name,
+			DiskDevice: kvcorev1.DiskDevice{
+				Disk: &kvcorev1.DiskTarget{Bus: kvcorev1.DiskBusVirtio},
+			},
+		})
+	}
+}
+
+func WithHugePages() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Memory = &kvcorev1.Memory{
+			Hugepages: &kvcorev1.Hugepages{PageSize: "1Gi"},
+		}
+	}
+}
+
+func WithResources(cpu, memory string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Resources = kvcorev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+		}
+	}
+}
+
+func WithNodeSelector(nodeName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if nodeName == "" {
+			return
+		}
+
+		if vmi.Spec.NodeSelector == nil {
+			vmi.Spec.NodeSelector = map[string]string{}
+		}
+
+		vmi.Spec.NodeSelector[corev1.LabelHostname] = nodeName
+	}
+}
+
+func WithZeroTerminationGracePeriodSeconds() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.TerminationGracePeriodSeconds = Pointer(int64(0))
+	}
+}
+
+func WithPVCVolume(volumeName, pvcName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		newVolume := kvcorev1.Volume{
+			Name: volumeName,
+			VolumeSource: kvcorev1.VolumeSource{
+				PersistentVolumeClaim: &kvcorev1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+				},
+			},
+		}
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newVolume)
+	}
+}
+
+func WithCloudInitNoCloudVolume(name, userData string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		newVolume := kvcorev1.Volume{
+			Name: name,
+			VolumeSource: kvcorev1.VolumeSource{
+				CloudInitNoCloud: &kvcorev1.CloudInitNoCloudSource{
+					UserData: userData,
+				},
+			},
+		}
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newVolume)
+	}
+}
+
+func Pointer[T any](v T) *T {
+	return &v
+}

--- a/pkg/internal/checkup/vmi/vmi_test.go
+++ b/pkg/internal/checkup/vmi/vmi_test.go
@@ -1,0 +1,302 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vmi_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+
+	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup/vmi"
+)
+
+const testVMIName = "my-vm"
+
+func TestNew(t *testing.T) {
+	actualVMI := vmi.New(testVMIName)
+	expectedVMI := newBaseVMI()
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithOwnerReference(t *testing.T) {
+	const (
+		testPodName = "rt-checkup-1234"
+		testPodUID  = "0123456789-0123456789"
+	)
+
+	actualVMI := vmi.New(testVMIName, vmi.WithOwnerReference(testPodName, testPodUID))
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       testPodName,
+			UID:        testPodUID,
+		},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithoutCRIOCPULoadBalancing(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithoutCRIOCPULoadBalancing())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.ObjectMeta.Annotations = map[string]string{
+		vmi.CRIOCPULoadBalancingAnnotation: vmi.Disable,
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithoutCRIOCPUQuota(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithoutCRIOCPUQuota())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.ObjectMeta.Annotations = map[string]string{
+		vmi.CRIOCPUQuotaAnnotation: vmi.Disable,
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithoutCRIOIRQLoadBalancing(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithoutCRIOIRQLoadBalancing())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.ObjectMeta.Annotations = map[string]string{
+		vmi.CRIOIRQLoadBalancingAnnotation: vmi.Disable,
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithRealtimeCPU(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithRealtimeCPU())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.CPU = &kvcorev1.CPU{
+		Model:                 "host-passthrough",
+		DedicatedCPUPlacement: true,
+		IsolateEmulatorThread: true,
+
+		Features: []kvcorev1.CPUFeature{
+			{Name: "tsc-deadline", Policy: "require"},
+		},
+		NUMA: &kvcorev1.NUMA{
+			GuestMappingPassthrough: &kvcorev1.NUMAGuestMappingPassthrough{},
+		},
+		Realtime: &kvcorev1.Realtime{Mask: "1-2"},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithoutAutoattachGraphicsDevice(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithoutAutoAttachGraphicsDevice())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.Devices.AutoattachGraphicsDevice = vmi.Pointer(false)
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithoutAutoattachMemBalloon(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithoutAutoAttachMemBalloon())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.Devices.AutoattachMemBalloon = vmi.Pointer(false)
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithAutoattachSerialConsole(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithAutoAttachSerialConsole())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.Devices.AutoattachSerialConsole = vmi.Pointer(true)
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithVirtIODisk(t *testing.T) {
+	const disk1Name = "rootdisk"
+	const disk2Name = "my-disk2"
+
+	actualVMI := vmi.New(testVMIName,
+		vmi.WithVirtIODisk(disk1Name),
+		vmi.WithVirtIODisk(disk2Name),
+	)
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.Devices.Disks = []kvcorev1.Disk{
+		{
+			Name: disk1Name,
+			DiskDevice: kvcorev1.DiskDevice{
+				Disk: &kvcorev1.DiskTarget{Bus: kvcorev1.DiskBusVirtio},
+			},
+		},
+		{
+			Name: disk2Name,
+			DiskDevice: kvcorev1.DiskDevice{
+				Disk: &kvcorev1.DiskTarget{Bus: kvcorev1.DiskBusVirtio},
+			},
+		},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithHugePages(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithHugePages())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.Memory = &kvcorev1.Memory{
+		Hugepages: &kvcorev1.Hugepages{PageSize: "1Gi"},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithResources(t *testing.T) {
+	const (
+		cpu    = "3"
+		memory = "8Gi"
+	)
+	actualVMI := vmi.New(testVMIName, vmi.WithResources(cpu, memory))
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Domain.Resources = kvcorev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpu),
+			corev1.ResourceMemory: resource.MustParse(memory),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpu),
+			corev1.ResourceMemory: resource.MustParse(memory),
+		},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithNodeSelectorWhen(t *testing.T) {
+	t.Run("hostname is not empty", func(t *testing.T) {
+		const nodeName = "my-node"
+		actualVMI := vmi.New(testVMIName, vmi.WithNodeSelector(nodeName))
+
+		expectedVMI := newBaseVMI()
+		expectedVMI.Spec.NodeSelector = map[string]string{
+			corev1.LabelHostname: nodeName,
+		}
+
+		assert.Equal(t, expectedVMI, actualVMI)
+	})
+
+	t.Run("hostname is empty", func(t *testing.T) {
+		actualVMI := vmi.New(testVMIName, vmi.WithNodeSelector(""))
+
+		expectedVMI := newBaseVMI()
+		expectedVMI.Spec.NodeSelector = nil
+
+		assert.Equal(t, expectedVMI, actualVMI)
+	})
+}
+
+func TestNewWithTerminationGracePeriodSeconds(t *testing.T) {
+	actualVMI := vmi.New(testVMIName, vmi.WithZeroTerminationGracePeriodSeconds())
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.TerminationGracePeriodSeconds = vmi.Pointer(int64(0))
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithPVCVolume(t *testing.T) {
+	const (
+		volumeName = "rootdisk"
+		pvcName    = "centos-8-rt"
+	)
+
+	actualVMI := vmi.New(testVMIName, vmi.WithPVCVolume(volumeName, pvcName))
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Volumes = []kvcorev1.Volume{
+		{
+			Name: volumeName,
+			VolumeSource: kvcorev1.VolumeSource{
+				PersistentVolumeClaim: &kvcorev1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func TestNewWithCloudInitNoCloudVolume(t *testing.T) {
+	const (
+		volumeName = "rootdisk"
+		userData   = `#cloud-config
+password: redhat
+chpasswd:
+  expire: false
+user: user`
+	)
+
+	actualVMI := vmi.New(testVMIName, vmi.WithCloudInitNoCloudVolume(volumeName, userData))
+
+	expectedVMI := newBaseVMI()
+	expectedVMI.Spec.Volumes = []kvcorev1.Volume{
+		{
+			Name: volumeName,
+			VolumeSource: kvcorev1.VolumeSource{
+				CloudInitNoCloud: &kvcorev1.CloudInitNoCloudSource{
+					UserData: userData,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expectedVMI, actualVMI)
+}
+
+func newBaseVMI() *kvcorev1.VirtualMachineInstance {
+	return &kvcorev1.VirtualMachineInstance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kvcorev1.VirtualMachineInstanceGroupVersionKind.Kind,
+			APIVersion: kvcorev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testVMIName,
+		},
+	}
+}

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/reporter"
 )
 
-func Run(rawEnv map[string]string) error {
+func Run(rawEnv map[string]string, namespace string) error {
 	c, err := client.New()
 	if err != nil {
 		return err

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -52,7 +52,10 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 	l := launcher.New(checkup.New(), reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName))
 
-	return l.Run(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), baseConfig.Timeout)
+	defer cancel()
+
+	return l.Run(ctx)
 }
 
 func printConfig(checkupConfig config.Config) {

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -50,7 +50,7 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 	printConfig(cfg)
 
-	l := launcher.New(checkup.New(), reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName))
+	l := launcher.New(checkup.New(c, namespace, cfg), reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), baseConfig.Timeout)
 	defer cancel()

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -255,11 +255,11 @@ func newConfigMap() *corev1.ConfigMap {
 			Name: testConfigMapName,
 		},
 		Data: map[string]string{
-			"spec.timeout":                                 "1m",
-			"spec.param.targetNode":                        "my-node",
+			"spec.timeout":                                 "15m",
+			"spec.param.targetNode":                        "",
 			"spec.param.guestImageSourcePVCNamespace":      testNamespace,
-			"spec.param.guestImageSourcePVCName":           "my-rt-vm",
-			"spec.param.oslatDuration":                     "6m",
+			"spec.param.guestImageSourcePVCName":           "centos-8-rt",
+			"spec.param.oslatDuration":                     "10m",
 			"spec.param.oslatLatencyThresholdMicroSeconds": "45",
 		},
 	}

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -328,6 +328,7 @@ k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
Create the VirtualMachineInstance object to be used as a test subject.

A follow-up PR will also wait for the VMI to boot.

The VMI object is created with a random suffix, in order to enable execution of multiple checkup instances simultaneously.

The e2e test was manually executed against an OpenShift 4.11 cluster, with a RT configured node.
The VMI had booted successfully.