### PR TITLE
Rename kubevirt-rt-checkup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,7 @@ linters-settings:
     lines: 100
     statements: 50
   gci:
-    local-prefixes: github.com/kiagnose/kubevirt-rt-checkup
+    local-prefixes: github.com/kiagnose/kubevirt-realtime-checkup
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -30,7 +30,7 @@ linters-settings:
   gocyclo:
     min-complexity: 15
   goimports:
-    local-prefixes: github.com/kiagnose/kubevirt-rt-checkup
+    local-prefixes: github.com/kiagnose/kubevirt-realtime-checkup
   gomnd:
     settings:
       mnd:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN microdnf install -y shadow-utils && \
     microdnf remove -y shadow-utils && \
     microdnf clean all
 
-COPY ./bin/kubevirt-rt-checkup /usr/local/bin
+COPY ./bin/kubevirt-realtime-checkup /usr/local/bin
 
 USER 900
 
-ENTRYPOINT ["kubevirt-rt-checkup"]
+ENTRYPOINT ["kubevirt-realtime-checkup"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CONTAINER_ENGINE ?= podman
 
-CHECKUP_IMAGE_NAME ?= quay.io/kiagnose/kubevirt-rt-checkup
+CHECKUP_IMAGE_NAME ?= quay.io/kiagnose/kubevirt-realtime-checkup
 CHECKUP_IMAGE_TAG ?= devel
 
 GO_IMAGE_NAME := docker.io/library/golang
@@ -9,7 +9,7 @@ GO_IMAGE_TAG := 1.19.4-bullseye
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
 LINTER_IMAGE_TAG := v1.50.1
 
-PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-rt-checkup
+PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-realtime-checkup
 
 all: lint unit-test build
 .PHONY: all
@@ -22,7 +22,7 @@ build:
 		-v $(PWD)/_go-cache:/root/.cache/go-build:Z \
 		--workdir $(PROJECT_WORKING_DIR) \
 		$(GO_IMAGE_NAME):$(GO_IMAGE_TAG) \
-		go build -v -o ./bin/kubevirt-rt-checkup ./cmd/
+		go build -v -o ./bin/kubevirt-realtime-checkup ./cmd/
 
 	$(CONTAINER_ENGINE) build . -t $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# kubevirt-rt-checkup
+# kubevirt-realtime-checkup

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,14 +25,14 @@ import (
 
 	"github.com/kiagnose/kiagnose/kiagnose/environment"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg"
 )
 
 func main() {
-	log.Println("kubevirt-rt-checkup starting...")
+	log.Println("kubevirt-realtime-checkup starting...")
 	rawEnv := environment.EnvToMap(os.Environ())
 
-	const errMessagePrefix = "kubevirt-rt-checkup failed"
+	const errMessagePrefix = "kubevirt-realtime-checkup failed"
 
 	namespace, err := environment.ReadNamespaceFile()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kiagnose/kubevirt-rt-checkup
+module github.com/kiagnose/kubevirt-realtime-checkup
 
 go 1.19
 

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -31,9 +31,9 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup/vmi"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/config"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/checkup/vmi"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/config"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/status"
 )
 
 type kubeVirtVMIClient interface {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -33,9 +33,9 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/config"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/checkup"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/config"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/status"
 )
 
 const (

--- a/pkg/internal/checkup/vmi/vmi_test.go
+++ b/pkg/internal/checkup/vmi/vmi_test.go
@@ -30,7 +30,7 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup/vmi"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/checkup/vmi"
 )
 
 const testVMIName = "my-vm"

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -27,7 +27,7 @@ import (
 
 	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/config"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/config"
 )
 
 const (

--- a/pkg/internal/launcher/launcher.go
+++ b/pkg/internal/launcher/launcher.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/status"
 )
 
 type checkup interface {

--- a/pkg/internal/launcher/launcher_test.go
+++ b/pkg/internal/launcher/launcher_test.go
@@ -26,8 +26,8 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/launcher"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/launcher"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/status"
 )
 
 var (

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -26,7 +26,7 @@ import (
 
 	kreporter "github.com/kiagnose/kiagnose/kiagnose/reporter"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/status"
 )
 
 const (

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -34,8 +34,8 @@ import (
 
 	kconfigmap "github.com/kiagnose/kiagnose/kiagnose/configmap"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/reporter"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/status"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/reporter"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/status"
 )
 
 const (

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -25,11 +25,11 @@ import (
 
 	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
 
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/checkup"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/client"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/config"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/launcher"
-	"github.com/kiagnose/kubevirt-rt-checkup/pkg/internal/reporter"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/checkup"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/client"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/config"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/launcher"
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/reporter"
 )
 
 func Run(rawEnv map[string]string, namespace string) error {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -20,7 +20,7 @@ const (
 
 const (
 	defaultNamespace = "kiagnose-demo"
-	defaultImageName = "quay.io/kiagnose/kubevirt-rt-checkup:main"
+	defaultImageName = "quay.io/kiagnose/kubevirt-realtime-checkup:main"
 )
 
 var (


### PR DESCRIPTION
Rename the repo to `kubevirt-realtime-checkup` in order for its name to be more explicit.