### PR TITLE
Build custom VM container disk image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 
 _go-cache
 _linter-cache
+_virt_builder

--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,7 @@ build-vm-image: build-vm-image-builder
 build-vm-container-disk: build-vm-image
 	$(CONTAINER_ENGINE) build $(CURDIR) -f $(CURDIR)/vms/vm-under-test/Dockerfile -t $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
 .PHONY: build-vm-container-disk
+
+push-vm-container-disk:
+	$(CONTAINER_ENGINE) push $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
+.PHONY: push-vm-container-disk

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
 VIRT_BUILDER_CACHE_DIR := $(CURDIR)/_virt_builder/cache
 VIRT_BUILDER_OUTPUT_DIR := $(CURDIR)/_virt_builder/output
 
+VM_CONTAINER_DISK_IMAGE_NAME := kubevirt-realtime-checkup-vm
+VM_CONTAINER_DISK_IMAGE_TAG ?= latest
+
 GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.19.4-bullseye
 
@@ -102,3 +105,7 @@ build-vm-image: build-vm-image-builder
       $(REG)/$(ORG)/$(VM_IMAGE_BUILDER_IMAGE_NAME):$(VM_IMAGE_BUILDER_IMAGE_TAG) \
       /root/scripts/build-vm-image
 .PHONY: build-vm-image
+
+build-vm-container-disk: build-vm-image
+	$(CONTAINER_ENGINE) build $(CURDIR) -f $(CURDIR)/vms/vm-under-test/Dockerfile -t $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
+.PHONY: build-vm-container-disk

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 CONTAINER_ENGINE ?= podman
 
+REG ?= quay.io
+ORG ?= kiagnose
+
 CHECKUP_IMAGE_NAME ?= quay.io/kiagnose/kubevirt-realtime-checkup
 CHECKUP_IMAGE_TAG ?= devel
+
+VM_IMAGE_BUILDER_IMAGE_NAME := kubevirt-realtime-checkup-vm-image-builder
+VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
 
 GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.19.4-bullseye
@@ -77,3 +83,7 @@ lint:
 push:
 	$(CONTAINER_ENGINE) push $(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: push
+
+build-vm-image-builder:
+	$(CONTAINER_ENGINE) build $(CURDIR)/vms/image-builder -f $(CURDIR)/vms/image-builder/Dockerfile -t $(REG)/$(ORG)/$(VM_IMAGE_BUILDER_IMAGE_NAME):$(VM_IMAGE_BUILDER_IMAGE_TAG)
+.PHONY: build-vm-image-builder

--- a/vms/image-builder/Dockerfile
+++ b/vms/image-builder/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y guestfs-tools && \
+    dnf clean all

--- a/vms/vm-under-test/Dockerfile
+++ b/vms/vm-under-test/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY ./_virt_builder/output/kubevirt-realtime-checkup-vm.qcow2 /disk/

--- a/vms/vm-under-test/scripts/build-vm-image
+++ b/vms/vm-under-test/scripts/build-vm-image
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+export LIBGUESTFS_BACKEND=direct
+
+virt-builder centosstream-8 \
+  --format qcow2 \
+  --root-password password:redhat \
+  --install cloud-init \
+  --run /root/scripts/customize-vm \
+  --selinux-relabel \
+  --output /output/kubevirt-realtime-checkup-vm.qcow2

--- a/vms/vm-under-test/scripts/customize-vm
+++ b/vms/vm-under-test/scripts/customize-vm
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+systemctl disable NetworkManager-wait-online
+systemctl disable sshd


### PR DESCRIPTION
Currently, the checkup uses a hard-coded name of a PVC containing a custom image.
In order for the checkup to be usable for other users, build a container disk [1] image.

Process description:
1. Build the vm-image-builder container image - this will be the environment to build the custom qcow2 image.
2. Build the custom qcow2 image using `virt-builder` [2].
3. Containerize the qcow2 image, so it could be consumed by KubeVirt.
4. Push the container disk image to `quay.io/kiagnose/kubevirt-realtime-checkup-vm`.

```bash
make build-vm-container-disk
make push-vm-container-disk
```

A follow-up PR will add the URL of this image to the checkup's configuration.

Follow-up PR(s) will properly configure the guest for realtime operation.

[1] https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk
[2] https://libguestfs.org/virt-builder.1.html

Based on https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/50