### PR TITLE
github actions: Build and publish VM ContainerDiskImage

### DIFF
--- a/.github/workflows/vm_containerdisk.yaml
+++ b/.github/workflows/vm_containerdisk.yaml
@@ -1,0 +1,23 @@
+name: Build VM ContainerDisk
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release-**'
+    paths:
+      - 'vms/image-builder/**'
+      - 'vms/vm-under-test/**'
+
+ # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_containerDisk_image:
+    name: Build VM ContainerDisk Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Build the ContainerDisk image
+        run: make build-vm-container-disk

--- a/.github/workflows/vm_containerdisk_publish.yaml
+++ b/.github/workflows/vm_containerdisk_publish.yaml
@@ -1,0 +1,29 @@
+name: Publish VM ContainerDisk
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+ # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish_containerDisk_image:
+    name: Build and publish VM ContainerDisk Image
+    runs-on: ubuntu-latest
+    env:
+      VM_CONTAINER_DISK_IMAGE_TAG: ${{github.ref_name}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Build the ContainerDisk image
+        run: make build-vm-container-disk
+      - name: Login to quay.io
+        run:
+          podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Publish
+        run:
+          make push-vm-container-disk


### PR DESCRIPTION
Currently, the build and push of the VM's ContainerDisk image is performed manually.

Add a workflow to build the ContainerDisk image on PRs that changes the vm directory or one of its children.
Add a workflow to build and push the ContainerDisk image to quay when a PR gets merged, or when there is a new tagged version.

~~Depends on #25, please review only the last two commits.~~

Based on https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/65.