### PR TITLE
checkup, setup: wait for VMI to boot

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -67,6 +68,10 @@ func (c *Checkup) Setup(ctx context.Context) error {
 	}
 	c.vmi = createdVMI
 
+	if err := c.waitForVMIToBoot(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -90,6 +95,34 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 
 func (c *Checkup) Results() status.Results {
 	return status.Results{}
+}
+
+func (c *Checkup) waitForVMIToBoot(ctx context.Context) error {
+	vmiFullName := ObjectFullName(c.vmi.Namespace, c.vmi.Name)
+	log.Printf("Waiting for VMI %q to boot...", vmiFullName)
+
+	conditionFn := func(ctx context.Context) (bool, error) {
+		fetchedVMI, err := c.client.GetVirtualMachineInstance(ctx, c.vmi.Namespace, c.vmi.Name)
+		if err != nil {
+			return false, err
+		}
+
+		for _, condition := range fetchedVMI.Status.Conditions {
+			if condition.Type == kvcorev1.VirtualMachineInstanceAgentConnected && condition.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+	const pollInterval = 5 * time.Second
+	if err := wait.PollImmediateUntilWithContext(ctx, pollInterval, conditionFn); err != nil {
+		return fmt.Errorf("failed to wait for VMI %q to boot: %w", vmiFullName, err)
+	}
+
+	log.Printf("VMI %q had successfully booted", vmiFullName)
+
+	return nil
 }
 
 func (c *Checkup) deleteVMI(ctx context.Context) error {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -95,13 +95,12 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 		expectedReadFailure := errors.New("failed to read VMI")
 
 		testClient := newClientStub()
-		testClient.vmiReadFailure = expectedReadFailure
-
 		testCheckup := checkup.New(testClient, testNamespace, newTestConfig())
 
 		assert.NoError(t, testCheckup.Setup(context.Background()))
 		assert.NoError(t, testCheckup.Run(context.Background()))
 
+		testClient.vmiReadFailure = expectedReadFailure
 		assert.ErrorContains(t, testCheckup.Teardown(context.Background()), expectedReadFailure.Error())
 	})
 }

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Checkup execution", func() {
 	})
 
 	It("should complete successfully", func() {
-		Eventually(getJobConditions, 5*time.Minute, 5*time.Second).Should(
+		Eventually(getJobConditions, 15*time.Minute, 5*time.Second).Should(
 			ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(batchv1.JobComplete),
 				"Status": Equal(corev1.ConditionTrue),


### PR DESCRIPTION
Wait for the VMI to boot by waiting for its `VirtualMachineInstanceAgentConnected` condition to be true, or timeout.

Based on kiagnose/kubevirt-dpdk-checkup#31

~~Depends on PR #28, please skip the first commit.~~

This is a copy of PR https://github.com/kiagnose/kubevirt-realtime-checkup/pull/22 that was closed due to deletion of my fork.