### PR TITLE
Checkup, setup: Add setup context

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -62,13 +62,17 @@ func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config
 }
 
 func (c *Checkup) Setup(ctx context.Context) error {
-	createdVMI, err := c.client.CreateVirtualMachineInstance(ctx, c.namespace, c.vmi)
+	const setupTimeout = 10 * time.Minute
+	setupCtx, cancel := context.WithTimeout(ctx, setupTimeout)
+	defer cancel()
+
+	createdVMI, err := c.client.CreateVirtualMachineInstance(setupCtx, c.namespace, c.vmi)
 	if err != nil {
 		return err
 	}
 	c.vmi = createdVMI
 
-	if err := c.waitForVMIToBoot(ctx); err != nil {
+	if err := c.waitForVMIToBoot(setupCtx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, the setup is using the global context, which has the timeout set by the user.

In case the checkup had created the VMI, there is a wait for for the VMI to be ready, that does not fail until the global timeout.

If the user-supplied timeout is long, the checkup will wait for a long time before failing.

Add a context with a ten minutes timeout for the setup phase, derived from the global context.

Based on https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/196.