### PR TITLE
Align user-facing API with the DPDK checkup

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -188,7 +188,7 @@ user: user`
 		vmi.WithHugePages(),
 		vmi.WithResources("3", "8Gi"),
 		vmi.WithZeroTerminationGracePeriodSeconds(),
-		vmi.WithNodeSelector(checkupConfig.TargetNode),
+		vmi.WithNodeSelector(checkupConfig.VMUnderTestTargetNodeName),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.VMUnderTestContainerDiskImage),
 		vmi.WithVirtIODisk(rootDiskName),
 		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, userData),

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -192,10 +192,10 @@ func (cs *clientStub) VMIName() string {
 
 func newTestConfig() config.Config {
 	return config.Config{
-		PodName:               "",
-		PodUID:                "",
-		TargetNode:            testTargetNodeName,
-		OslatDuration:         10 * time.Minute,
-		OslatLatencyThreshold: 45 * time.Microsecond,
+		PodName:                   "",
+		PodUID:                    "",
+		VMUnderTestTargetNodeName: testTargetNodeName,
+		OslatDuration:             10 * time.Minute,
+		OslatLatencyThreshold:     45 * time.Microsecond,
 	}
 }

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	TargetNodeParamName                    = "targetNode"
+	VMUnderTestTargetNodeNameParamName     = "vmUnderTestTargetNodeName"
 	VMUnderTestContainerDiskImageParamName = "vmUnderTestContainerDiskImage"
 	OslatDurationParamName                 = "oslatDuration"
 	OslatLatencyThresholdParamName         = "oslatLatencyThresholdMicroSeconds"
@@ -48,7 +48,7 @@ var (
 type Config struct {
 	PodName                       string
 	PodUID                        string
-	TargetNode                    string
+	VMUnderTestTargetNodeName     string
 	VMUnderTestContainerDiskImage string
 	OslatDuration                 time.Duration
 	OslatLatencyThreshold         time.Duration
@@ -58,7 +58,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 	newConfig := Config{
 		PodName:                       baseConfig.PodName,
 		PodUID:                        baseConfig.PodUID,
-		TargetNode:                    baseConfig.Params[TargetNodeParamName],
+		VMUnderTestTargetNodeName:     baseConfig.Params[VMUnderTestTargetNodeNameParamName],
 		VMUnderTestContainerDiskImage: VMUnderTestDefaultContainerDiskImage,
 		OslatDuration:                 OslatDefaultDuration,
 		OslatLatencyThreshold:         OslatDefaultLatencyThreshold,

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -33,7 +33,7 @@ import (
 const (
 	testPodName                           = "my-pod"
 	testPodUID                            = "0123456789-0123456789"
-	testTargetNodeName                    = "my-rt-node"
+	testVMUnderTestTargetNodeName         = "my-rt-node"
 	testVMContainerDiskImage              = "quay.io/myorg/kubevirt-realtime-checkup-vm:latest"
 	testOslatDuration                     = "1h"
 	testOslatLatencyThresholdMicroSeconds = "50"
@@ -52,7 +52,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 	expectedConfig := config.Config{
 		PodName:                       testPodName,
 		PodUID:                        testPodUID,
-		TargetNode:                    "",
+		VMUnderTestTargetNodeName:     "",
 		VMUnderTestContainerDiskImage: config.VMUnderTestDefaultContainerDiskImage,
 		OslatDuration:                 config.OslatDefaultDuration,
 		OslatLatencyThreshold:         config.OslatDefaultLatencyThreshold,
@@ -65,7 +65,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 		PodName: testPodName,
 		PodUID:  testPodUID,
 		Params: map[string]string{
-			config.TargetNodeParamName:                    testTargetNodeName,
+			config.VMUnderTestTargetNodeNameParamName:     testVMUnderTestTargetNodeName,
 			config.VMUnderTestContainerDiskImageParamName: testVMContainerDiskImage,
 			config.OslatDurationParamName:                 testOslatDuration,
 			config.OslatLatencyThresholdParamName:         testOslatLatencyThresholdMicroSeconds,
@@ -78,7 +78,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 	expectedConfig := config.Config{
 		PodName:                       testPodName,
 		PodUID:                        testPodUID,
-		TargetNode:                    testTargetNodeName,
+		VMUnderTestTargetNodeName:     testVMUnderTestTargetNodeName,
 		VMUnderTestContainerDiskImage: testVMContainerDiskImage,
 		OslatDuration:                 time.Hour,
 		OslatLatencyThreshold:         50 * time.Microsecond,
@@ -97,18 +97,18 @@ func TestNewShouldFailWhen(t *testing.T) {
 		{
 			description: "oslatDuration is invalid",
 			userParameters: map[string]string{
-				config.TargetNodeParamName:            testTargetNodeName,
-				config.OslatDurationParamName:         "wrongValue",
-				config.OslatLatencyThresholdParamName: testOslatLatencyThresholdMicroSeconds,
+				config.VMUnderTestTargetNodeNameParamName: testVMUnderTestTargetNodeName,
+				config.OslatDurationParamName:             "wrongValue",
+				config.OslatLatencyThresholdParamName:     testOslatLatencyThresholdMicroSeconds,
 			},
 			expectedError: config.ErrInvalidOslatDuration,
 		},
 		{
 			description: "oslatLatencyThresholdMicroSeconds is invalid",
 			userParameters: map[string]string{
-				config.TargetNodeParamName:            testTargetNodeName,
-				config.OslatDurationParamName:         testOslatDuration,
-				config.OslatLatencyThresholdParamName: "wrongValue",
+				config.VMUnderTestTargetNodeNameParamName: testVMUnderTestTargetNodeName,
+				config.OslatDurationParamName:             testOslatDuration,
+				config.OslatLatencyThresholdParamName:     "wrongValue",
 			},
 			expectedError: config.ErrInvalidOslatLatencyThreshold,
 		},

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	NodeKey            = "node"
-	OslatMaxLatencyKey = "oslatMaxLatencyMicroSeconds"
+	VMUnderTestActualNodeNameKey = "vmUnderTestActualNodeName"
+	OslatMaxLatencyKey           = "oslatMaxLatencyMicroSeconds"
 )
 
 type Reporter struct {
@@ -62,8 +62,8 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	}
 
 	formattedResults := map[string]string{
-		NodeKey:            checkupStatus.Results.Node,
-		OslatMaxLatencyKey: fmt.Sprintf("%d", checkupStatus.Results.OslatMaxLatency.Microseconds()),
+		VMUnderTestActualNodeNameKey: checkupStatus.Results.VMUnderTestActualNodeName,
+		OslatMaxLatencyKey:           fmt.Sprintf("%d", checkupStatus.Results.OslatMaxLatency.Microseconds()),
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -52,7 +52,7 @@ func TestReportShouldSucceed(t *testing.T) {
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
-		expectedNodeName = "rt-node"
+		expectedVMUnderTestActualNodeName = "rt-node"
 	)
 
 	const (
@@ -71,8 +71,8 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.FailureReason = []string{}
 		checkupStatus.CompletionTimestamp = time.Now()
 		checkupStatus.Results = status.Results{
-			Node:            expectedNodeName,
-			OslatMaxLatency: 12 * time.Microsecond,
+			VMUnderTestActualNodeName: expectedVMUnderTestActualNodeName,
+			OslatMaxLatency:           12 * time.Microsecond,
 		}
 
 		assert.NoError(t, testReporter.Report(checkupStatus))
@@ -82,7 +82,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.failureReason":                      "",
 			"status.startTimestamp":                     timestamp(checkupStatus.StartTimestamp),
 			"status.completionTimestamp":                timestamp(checkupStatus.CompletionTimestamp),
-			"status.result.node":                        checkupStatus.Results.Node,
+			"status.result.vmUnderTestActualNodeName":   checkupStatus.Results.VMUnderTestActualNodeName,
 			"status.result.oslatMaxLatencyMicroSeconds": fmt.Sprintf("%d", checkupStatus.Results.OslatMaxLatency.Microseconds()),
 		}
 

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -26,8 +26,8 @@ import (
 )
 
 type Results struct {
-	Node            string
-	OslatMaxLatency time.Duration
+	VMUnderTestActualNodeName string
+	OslatMaxLatency           time.Duration
 }
 
 type Status struct {

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -60,7 +60,7 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 func printConfig(checkupConfig config.Config) {
 	log.Println("Using the following config:")
-	log.Printf("\t%q: %q", config.TargetNodeParamName, checkupConfig.TargetNode)
+	log.Printf("\t%q: %q", config.VMUnderTestTargetNodeNameParamName, checkupConfig.VMUnderTestTargetNodeName)
 	log.Printf("\t%q: %q", config.VMUnderTestContainerDiskImageParamName, checkupConfig.VMUnderTestContainerDiskImage)
 	log.Printf("\t%q: %q", config.OslatDurationParamName, checkupConfig.OslatDuration.String())
 	log.Printf("\t%q: %q", config.OslatLatencyThresholdParamName, checkupConfig.OslatLatencyThreshold.String())

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -252,7 +252,7 @@ func newRoleBinding(name, serviceAccountName, roleName string) *rbacv1.RoleBindi
 func newConfigMap() *corev1.ConfigMap {
 	testConfig := map[string]string{
 		"spec.timeout":                                 "15m",
-		"spec.param.targetNode":                        "",
+		"spec.param.vmUnderTestTargetNodeName":         "",
 		"spec.param.oslatDuration":                     "10m",
 		"spec.param.oslatLatencyThresholdMicroSeconds": "45",
 	}


### PR DESCRIPTION
Rename the `targetNode` parameter to `vmUnderTestTargetNodeName`.
Rename `node` output field to `vmUnderTestActualNodeName`.

Note: The `README.md` file is already up-to-date.