### PR TITLE
tests-e2e: Fix broken use of vmUnderTestContainerDiskImageEnvVarName

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	namespaceEnvVarName                     = "TEST_NAMESPACE"
 	imageEnvVarName                         = "TEST_CHECKUP_IMAGE"
-	vmUnderTestContainerDiskImageEnvVarName = "VM_CONTAINER_DISK_IMAGE_URL"
+	vmUnderTestContainerDiskImageEnvVarName = "VM_UNDER_TEST_CONTAINER_DISK_IMAGE"
 )
 
 const (


### PR DESCRIPTION
vmUnderTestContainerDiskImageEnvVarName is currently pointing to an unused env var "VM_CONTAINER_DISK_IMAGE_URL".
Fixing to the correct env var: "VM_UNDER_TEST_CONTAINER_DISK_IMAGE"