### PR TITLE
Checkup, vmi spec: Don't use host huge pages

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -171,7 +171,6 @@ func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstanc
 		CPUSocketsCount   = 1
 		CPUCoresCount     = 3
 		CPUTreadsCount    = 1
-		hugePageSize      = "1Gi"
 		guestMemory       = "4Gi"
 		rootDiskName      = "rootdisk"
 		cloudInitDiskName = "cloudinitdisk"
@@ -187,7 +186,7 @@ user: user`
 		vmi.WithoutCRIOCPUQuota(),
 		vmi.WithoutCRIOIRQLoadBalancing(),
 		vmi.WithRealtimeCPU(CPUSocketsCount, CPUCoresCount, CPUTreadsCount),
-		vmi.WithMemory(hugePageSize, guestMemory),
+		vmi.WithMemory(guestMemory),
 		vmi.WithoutAutoAttachGraphicsDevice(),
 		vmi.WithoutAutoAttachMemBalloon(),
 		vmi.WithAutoAttachSerialConsole(),

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -159,12 +159,11 @@ func WithVirtIODisk(name string) Option {
 	}
 }
 
-func WithMemory(hugePageSize, guestMemory string) Option {
+func WithMemory(guestMemory string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		guestMemoryQuantity := resource.MustParse(guestMemory)
 		vmi.Spec.Domain.Memory = &kvcorev1.Memory{
-			Hugepages: &kvcorev1.Hugepages{PageSize: hugePageSize},
-			Guest:     &guestMemoryQuantity,
+			Guest: &guestMemoryQuantity,
 		}
 	}
 }


### PR DESCRIPTION
There is no need to use the host's huge pages as the memory backend of the vm under test.