### PR TITLE
Revert "Checkup, vmi spec: Don't use host huge pages"

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -171,6 +171,7 @@ func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstanc
 		CPUSocketsCount   = 1
 		CPUCoresCount     = 3
 		CPUTreadsCount    = 1
+		hugePageSize      = "1Gi"
 		guestMemory       = "4Gi"
 		rootDiskName      = "rootdisk"
 		cloudInitDiskName = "cloudinitdisk"
@@ -186,7 +187,7 @@ user: user`
 		vmi.WithoutCRIOCPUQuota(),
 		vmi.WithoutCRIOIRQLoadBalancing(),
 		vmi.WithRealtimeCPU(CPUSocketsCount, CPUCoresCount, CPUTreadsCount),
-		vmi.WithMemory(guestMemory),
+		vmi.WithMemory(hugePageSize, guestMemory),
 		vmi.WithoutAutoAttachGraphicsDevice(),
 		vmi.WithoutAutoAttachMemBalloon(),
 		vmi.WithAutoAttachSerialConsole(),

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -159,11 +159,12 @@ func WithVirtIODisk(name string) Option {
 	}
 }
 
-func WithMemory(guestMemory string) Option {
+func WithMemory(hugePageSize, guestMemory string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		guestMemoryQuantity := resource.MustParse(guestMemory)
 		vmi.Spec.Domain.Memory = &kvcorev1.Memory{
-			Guest: &guestMemoryQuantity,
+			Hugepages: &kvcorev1.Hugepages{PageSize: hugePageSize},
+			Guest:     &guestMemoryQuantity,
 		}
 	}
 }


### PR DESCRIPTION
Reverts kiagnose/kubevirt-realtime-checkup#38