### PR TITLE
Makefile: Bump go to 1.20.12

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: katexochen/go-tidy-check@v1
+      - uses: katexochen/go-tidy-check@v2
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ VM_CONTAINER_DISK_IMAGE_NAME := kubevirt-realtime-checkup-vm
 VM_CONTAINER_DISK_IMAGE_TAG ?= latest
 
 GO_IMAGE_NAME := docker.io/library/golang
-GO_IMAGE_TAG := 1.19.4-bullseye
+GO_IMAGE_TAG := 1.20.12
 
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
 LINTER_IMAGE_TAG := v1.50.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiagnose/kubevirt-realtime-checkup
 
-go 1.19
+go 1.20
 
 require (
 	github.com/kiagnose/kiagnose v0.2.1-0.20221208132946-95d8c7995fab


### PR DESCRIPTION
Use the default go image tag.
Bump the `go mod tidy` github action.