### PR TITLE
VMI spec: Always pull container disk image

### DIFF
--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -195,7 +195,8 @@ func WithContainerDisk(volumeName, imageName string) Option {
 			Name: volumeName,
 			VolumeSource: kvcorev1.VolumeSource{
 				ContainerDisk: &kvcorev1.ContainerDiskSource{
-					Image: imageName,
+					Image:           imageName,
+					ImagePullPolicy: corev1.PullAlways,
 				},
 			},
 		}


### PR DESCRIPTION
Currently, the ImagePullPolicy on the container disk image is undefined, thus defaults to `IfNotPresent` [1].

Since we are using a single tag to represent the current state of the `main` branch, the image is not pulled again when there are updates to the VM under test's container disk image.

Set the ImagePullPolicy to `Always`[2].

[1] https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
[2] https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy