### PR TITLE
checkup, results: Add node params

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -94,6 +94,7 @@ func (c *Checkup) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	c.results.VMUnderTestActualNodeName = c.vmi.Status.NodeName
 
 	return nil
 }


### PR DESCRIPTION
This PR is updating the node the VMI under test was scheduled on.