### PR TITLE
Checkup: Save VMI state after boot

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -104,6 +104,8 @@ var _ = Describe("Checkup execution", func() {
 		Expect(configMap.Data).NotTo(BeNil())
 		Expect(configMap.Data["status.succeeded"]).To(Equal("true"), fmt.Sprintf("should succeed %+v", configMap.Data))
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", configMap.Data))
+		Expect(configMap.Data["status.result.vmUnderTestActualNodeName"]).
+			ToNot(BeEmpty(), fmt.Sprintf("vmUnderTestActualNodeName should not be empty %+v", configMap.Data))
 	})
 })
 


### PR DESCRIPTION
Currently, the `status.result.vmUnderTestActualNodeName` output field is not reported.

This is caused do to Checkup not saving the updated VMI object after it booted.

Save the updated VMI object.
Add an E2E test to make sure the above output field is not empty.

This is a follow-up to PR #48.