### PR TITLE
Bump base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1.0-1656.1669627757
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1475
 
 RUN microdnf install -y shadow-utils && \
     adduser --system --no-create-home -u 900 rt-checkup && \


### PR DESCRIPTION
Bump the checkup's base image to
`registry.access.redhat.com/ubi9/ubi-minimal:9.3-1475`.