### PR TITLE
VMI spec: Add owner reference

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -194,6 +194,7 @@ func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstanc
 	)
 
 	return vmi.New(randomizeName(VMINamePrefix),
+		vmi.WithOwnerReference(checkupConfig.PodName, checkupConfig.PodUID),
 		vmi.WithoutCRIOCPULoadBalancing(),
 		vmi.WithoutCRIOCPUQuota(),
 		vmi.WithoutCRIOIRQLoadBalancing(),

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -321,6 +321,14 @@ func newCheckupJob() *batchv1.Job {
 									Name:  "CONFIGMAP_NAME",
 									Value: testConfigMapName,
 								},
+								{
+									Name: "POD_UID",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.uid",
+										},
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Follow the convention from the other checkups, and have the VMI under test to be owned by the checkup's pod.