### PR TITLE
Checkup: Rename VMI-under-test name prefix

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -59,7 +59,7 @@ type Checkup struct {
 	cfg       config.Config
 }
 
-const VMINamePrefix = "rt-vmi"
+const VMINamePrefix = "realtime-vmi-under-test"
 
 func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config, executor testExecutor) *Checkup {
 	return &Checkup{


### PR DESCRIPTION
Currently, the VMI-under-test name prefix is `rt-vmi`. Rename it to `realtime-vmi-under-test` in order
to better convey its purpose.