### PR TITLE
e2e, reporter: Collect test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 _go-cache
 _linter-cache
 _virt_builder
+_output

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,13 @@ PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-realtime-checkup
 E2E_TEST_TIMEOUT ?= 1h
 E2E_TEST_ARGS ?= -test.v -test.timeout=$(E2E_TEST_TIMEOUT) -ginkgo.v -ginkgo.timeout=$(E2E_TEST_TIMEOUT) $(E2E_TEST_EXTRA_ARGS)
 
+ARTIFACTS_DIR ?= _output
+
 all: lint unit-test build
 .PHONY: all
 
 build:
-	mkdir -p $(PWD)/_go-cache
+	mkdir -p _go-cache
 
 	$(CONTAINER_ENGINE) run --rm \
 		-v $(PWD):$(PROJECT_WORKING_DIR):Z \
@@ -77,6 +79,7 @@ e2e-test:
 		-e TEST_NAMESPACE=$(TEST_NAMESPACE) \
 		-e TEST_CHECKUP_IMAGE=$(TEST_CHECKUP_IMAGE) \
 		-e VM_UNDER_TEST_CONTAINER_DISK_IMAGE=$(VM_UNDER_TEST_CONTAINER_DISK_IMAGE) \
+		-e ARTIFACTS_DIR=$(ARTIFACTS_DIR) \
 		$(GO_IMAGE_NAME):$(GO_IMAGE_TAG) \
 		go test -v ./tests/... $(E2E_TEST_ARGS)
 .PHONY: e2e-test

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -52,6 +52,11 @@ var _ = Describe("Checkup execution", Ordered, func() {
 	BeforeAll(func() {
 		checkupReporter.Cleanup()
 	})
+
+	JustAfterEach(func() {
+		checkupReporter.CollectArtifacts()
+	})
+
 	BeforeEach(func() {
 		setupCheckupPermissions()
 

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -43,12 +43,15 @@ const (
 	testCheckupJobName                  = "realtime-checkup"
 )
 
-var _ = Describe("Checkup execution", func() {
+var _ = Describe("Checkup execution", Ordered, func() {
 	var (
 		configMap  *corev1.ConfigMap
 		checkupJob *batchv1.Job
 	)
 
+	BeforeAll(func() {
+		checkupReporter.Cleanup()
+	})
 	BeforeEach(func() {
 		setupCheckupPermissions()
 

--- a/tests/reporter/configmap/configmap.go
+++ b/tests/reporter/configmap/configmap.go
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package configmap
+
+import (
+	"context"
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetData(client *kubernetes.Clientset, namespace, configmapName string) (string, error) {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.Background(), configmapName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	dataPrettyJSON, err := json.MarshalIndent(cm.Data, "", "\t")
+	if err != nil {
+		return "", err
+	}
+	return string(dataPrettyJSON), nil
+}

--- a/tests/reporter/job/job.go
+++ b/tests/reporter/job/job.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package job
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetLogs(client *kubernetes.Clientset, namespace, jobName string) (string, error) {
+	jobPodName, err := getPodNameByJob(client, namespace, jobName)
+	if err != nil {
+		return "", err
+	}
+
+	rawLogs, err := client.CoreV1().Pods(namespace).GetLogs(jobPodName, &corev1.PodLogOptions{}).DoRaw(context.Background())
+	if err != nil {
+		return "", err
+	}
+	return string(rawLogs), nil
+}
+
+func getPodNameByJob(client *kubernetes.Clientset, namespace, jobName string) (string, error) {
+	const JobNameLabel = "job-name"
+	jobLabel := k8slabels.Set{JobNameLabel: jobName}
+	podList, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: jobLabel.String()})
+	if err != nil {
+		return "", err
+	}
+
+	if len(podList.Items) != 1 {
+		return "", fmt.Errorf("failed to find job's pod: found %d pods for Job %s/%s", len(podList.Items), namespace, jobName)
+	}
+	return podList.Items[0].Name, nil
+}

--- a/tests/reporter/reporter.go
+++ b/tests/reporter/reporter.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package reporter
+
+import (
+	"os"
+	"path"
+)
+
+type CheckupReporter struct {
+	ArtifactsDir string
+}
+
+func New(params CheckupReporter) *CheckupReporter {
+	return &CheckupReporter{
+		ArtifactsDir: params.ArtifactsDir,
+	}
+}
+
+// Cleanup cleans up the current content of the artifactsDir
+func (c CheckupReporter) Cleanup() {
+	// clean up artifacts from previous run
+	if c.ArtifactsDir != "" {
+		_, err := os.Stat(c.ArtifactsDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return
+			} else {
+				panic(err)
+			}
+		}
+		names, err := os.ReadDir(c.ArtifactsDir)
+		if err != nil {
+			panic(err)
+		}
+		for _, entry := range names {
+			os.RemoveAll(path.Join([]string{c.ArtifactsDir, entry.Name()}...))
+		}
+	}
+}

--- a/tests/reporter/reporter.go
+++ b/tests/reporter/reporter.go
@@ -20,17 +20,31 @@
 package reporter
 
 import (
+	"fmt"
 	"os"
 	"path"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kiagnose/kubevirt-realtime-checkup/tests/reporter/configmap"
+	"github.com/kiagnose/kubevirt-realtime-checkup/tests/reporter/job"
 )
 
 type CheckupReporter struct {
-	ArtifactsDir string
+	Client        *kubernetes.Clientset
+	ArtifactsDir  string
+	Namespace     string
+	JobName       string
+	ConfigMapName string
 }
 
 func New(params CheckupReporter) *CheckupReporter {
 	return &CheckupReporter{
-		ArtifactsDir: params.ArtifactsDir,
+		Client:        params.Client,
+		ArtifactsDir:  params.ArtifactsDir,
+		Namespace:     params.Namespace,
+		JobName:       params.JobName,
+		ConfigMapName: params.ConfigMapName,
 	}
 }
 
@@ -53,5 +67,50 @@ func (c CheckupReporter) Cleanup() {
 		for _, entry := range names {
 			os.RemoveAll(path.Join([]string{c.ArtifactsDir, entry.Name()}...))
 		}
+	}
+}
+
+// CollectArtifacts collects the artifacts to artifactsDir
+func (c CheckupReporter) CollectArtifacts() {
+	const folderPermission = 0755
+	err := os.MkdirAll(c.ArtifactsDir, folderPermission)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	checkupJobLogs, err := job.GetLogs(c.Client, c.Namespace, c.JobName)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	c.writeTestLogFile("job", c.JobName, checkupJobLogs)
+
+	configmapData, err := configmap.GetData(c.Client, c.Namespace, c.ConfigMapName)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	c.writeTestLogFile("configmap", c.ConfigMapName, configmapData)
+}
+
+func (c CheckupReporter) writeTestLogFile(objectType, objectName, logBuffer string) {
+	const filePermission = 0644
+
+	name := fmt.Sprintf("%s/%s_%s.log", c.ArtifactsDir, objectType, objectName)
+	fi, err := os.OpenFile(name, os.O_CREATE|os.O_APPEND|os.O_WRONLY, filePermission)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer func() {
+		if errFile := fi.Close(); errFile != nil {
+			fmt.Println(errFile)
+		}
+	}()
+	_, err = fi.WriteString(logBuffer)
+	if err != nil {
+		fmt.Println(err)
+		return
 	}
 }

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -66,6 +66,10 @@ var _ = BeforeSuite(func() {
 	artifactsDir := os.Getenv(artifactsEnvVarName)
 
 	checkupReporter = reporter.New(reporter.CheckupReporter{
-		ArtifactsDir: artifactsDir,
+		Client:        client,
+		ArtifactsDir:  artifactsDir,
+		Namespace:     testNamespace,
+		JobName:       testCheckupJobName,
+		ConfigMapName: testConfigMapName,
 	})
 })

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -11,12 +11,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+
+	"github.com/kiagnose/kubevirt-realtime-checkup/tests/reporter"
 )
 
 const (
 	namespaceEnvVarName                     = "TEST_NAMESPACE"
 	imageEnvVarName                         = "TEST_CHECKUP_IMAGE"
 	vmUnderTestContainerDiskImageEnvVarName = "VM_UNDER_TEST_CONTAINER_DISK_IMAGE"
+	artifactsEnvVarName                     = "ARTIFACTS_DIR"
 )
 
 const (
@@ -29,6 +32,7 @@ var (
 	testNamespace                 string
 	testImageName                 string
 	vmUnderTestContainerDiskImage string
+	checkupReporter               *reporter.CheckupReporter
 )
 
 func TestTests(t *testing.T) {
@@ -58,4 +62,10 @@ var _ = BeforeSuite(func() {
 	}
 
 	vmUnderTestContainerDiskImage = os.Getenv(vmUnderTestContainerDiskImageEnvVarName)
+
+	artifactsDir := os.Getenv(artifactsEnvVarName)
+
+	checkupReporter = reporter.New(reporter.CheckupReporter{
+		ArtifactsDir: artifactsDir,
+	})
 })


### PR DESCRIPTION
This PR introduces a reporter package that manages the artifacts collection after the checkup is run.
The artifacts are saved on "_output" folder which is located under the "test" folder