### PR TITLE
Setting the VMI-Under-Test CPUs to be four

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -198,7 +198,7 @@ func (c *Checkup) waitForVMIDeletion(ctx context.Context) error {
 func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 	const (
 		CPUSocketsCount   = 1
-		CPUCoresCount     = 3
+		CPUCoresCount     = 4
 		CPUTreadsCount    = 1
 		hugePageSize      = "1Gi"
 		guestMemory       = "4Gi"

--- a/pkg/internal/checkup/executor/oslat/client.go
+++ b/pkg/internal/checkup/executor/oslat/client.go
@@ -198,7 +198,7 @@ func getMaxLatencyValue(values []string, units string) (time.Duration, error) {
 
 func buildOslatCmd(testDuration time.Duration) string {
 	const (
-		cpuList          = "1-2"
+		cpuList          = "2-3"
 		realtimePriority = "1"
 		workload         = "memmove"
 		workloadMemory   = "4K"

--- a/pkg/internal/checkup/executor/oslat/client_test.go
+++ b/pkg/internal/checkup/executor/oslat/client_test.go
@@ -137,7 +137,7 @@ func (c fakeClock) Now() time.Time {
 }
 
 const (
-	oslatRunCmd             = "taskset -c 1-2 oslat --cpu-list 1-2 --rtprio 1 --duration 1m0s --workload memmove --workload-mem 4K \n"
+	oslatRunCmd             = "taskset -c 2-3 oslat --cpu-list 2-3 --rtprio 1 --duration 1m0s --workload memmove --workload-mem 4K \n"
 	oslatRunResultsTemplate = "oslat V 2.60\n" +
 		"Total runtime: \t\t60 seconds\n" +
 		"Thread priority: \tSCHED_FIFO:1\n" +

--- a/vms/vm-under-test/scripts/first-boot
+++ b/vms/vm-under-test/scripts/first-boot
@@ -21,7 +21,7 @@ set -e
 
 systemctl mask "$(systemctl --type swap | grep '.swap' | awk '{print $1}')"
 
-echo isolated_cores=1-2 >> /etc/tuned/realtime-virtual-guest-variables.conf
+echo isolated_cores=2-3 >> /etc/tuned/realtime-virtual-guest-variables.conf
 echo isolate_managed_irq=Y >> /etc/tuned/realtime-virtual-guest-variables.conf
 tuned-adm profile realtime-virtual-guest
 


### PR DESCRIPTION
This PR is changing the amount of CPUs requested to be four. 
Doing this allows the checkup to run the Oslat test on a full core (in this checkup - guest CPUs 2-3).
By doing this Oslat is optimized to not have neighboring CPU noise.
