### PR TITLE
Log in as root

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -197,13 +196,12 @@ func (c *Checkup) waitForVMIDeletion(ctx context.Context) error {
 
 func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 	const (
-		CPUSocketsCount   = 1
-		CPUCoresCount     = 4
-		CPUTreadsCount    = 1
-		hugePageSize      = "1Gi"
-		guestMemory       = "4Gi"
-		rootDiskName      = "rootdisk"
-		cloudInitDiskName = "cloudinitdisk"
+		CPUSocketsCount = 1
+		CPUCoresCount   = 4
+		CPUTreadsCount  = 1
+		hugePageSize    = "1Gi"
+		guestMemory     = "4Gi"
+		rootDiskName    = "rootdisk"
 	)
 
 	return vmi.New(randomizeName(VMINamePrefix),
@@ -221,8 +219,6 @@ func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstanc
 		vmi.WithNodeSelector(checkupConfig.VMUnderTestTargetNodeName),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.VMUnderTestContainerDiskImage),
 		vmi.WithVirtIODisk(rootDiskName),
-		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword)),
-		vmi.WithVirtIODisk(cloudInitDiskName),
 	)
 }
 
@@ -234,15 +230,4 @@ func randomizeName(prefix string) string {
 
 func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
-}
-
-func CloudInit(username, password string) string {
-	sb := strings.Builder{}
-	sb.WriteString("#cloud-config\n")
-	sb.WriteString(fmt.Sprintf("user: %s\n", username))
-	sb.WriteString(fmt.Sprintf("password: %s\n", password))
-	sb.WriteString("chpasswd:\n")
-	sb.WriteString("  expire: false")
-
-	return sb.String()
 }

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -89,17 +89,6 @@ func TestSetupShouldFail(t *testing.T) {
 	})
 }
 
-func TestCloudInitString(t *testing.T) {
-	actualString := checkup.CloudInit("user", "password")
-	expectedString := `#cloud-config
-user: user
-password: password
-chpasswd:
-  expire: false`
-
-	assert.Equal(t, expectedString, actualString)
-}
-
 func TestTeardownShouldFailWhen(t *testing.T) {
 	t.Run("VMI deletion fails", func(t *testing.T) {
 		expectedVMIDeletionFailure := errors.New("failed to delete VMI")

--- a/pkg/internal/checkup/executor/console/console.go
+++ b/pkg/internal/checkup/executor/console/console.go
@@ -182,26 +182,3 @@ func expectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 	res, err := expecter.ExpectBatch(batch, timeout)
 	return res, err
 }
-
-func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
-	sudoString := ""
-	if shouldSudo {
-		sudoString = "sudo "
-	}
-	batch := []expect.Batcher{
-		&expect.BSnd{S: "stty cols 500 rows 500\n"},
-		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")},
-		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
-		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")},
-	}
-	const configureConsoleTimeout = 30 * time.Second
-	resp, err := expecter.ExpectBatch(batch, configureConsoleTimeout)
-	if err != nil {
-		log.Printf("%v", resp)
-	}
-	return err
-}

--- a/pkg/internal/checkup/executor/console/login.go
+++ b/pkg/internal/checkup/executor/console/login.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func (e Expecter) LoginToCentOS(username, password string) error {
+func (e Expecter) LoginToCentOSAsRoot(password string) error {
 	const (
 		connectionTimeout = 10 * time.Second
 		promptTimeout     = 5 * time.Second
@@ -47,9 +47,7 @@ func (e Expecter) LoginToCentOS(username, password string) error {
 	}
 
 	// Do not login, if we already logged in
-	loggedInPromptRegex := fmt.Sprintf(
-		`(\[%s@(localhost|centos|%s) ~\]\$ |\[root@(localhost|centos|%s) ~\]\# )`, username, e.vmiName, e.vmiName,
-	)
+	loggedInPromptRegex := fmt.Sprintf(`(\[root@(localhost|centos|%s) ~\]\# )`, e.vmiName)
 	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: loggedInPromptRegex},
@@ -67,7 +65,7 @@ func (e Expecter) LoginToCentOS(username, password string) error {
 				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
 				// and in case the VM's did not get hostname form DHCP server try the default hostname
 				R:  regexp.MustCompile(fmt.Sprintf(`(localhost|centos|%s) login: `, e.vmiName)),
-				S:  fmt.Sprintf("%s\n", username),
+				S:  "root\n",
 				T:  expect.Next(),
 				Rt: 10,
 			},

--- a/pkg/internal/checkup/executor/console/login.go
+++ b/pkg/internal/checkup/executor/console/login.go
@@ -99,24 +99,20 @@ func (e Expecter) LoginToCentOS(username, password string) error {
 		}
 	}
 
-	err = configureConsole(genExpect, false)
+	err = configureConsole(genExpect)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
-	sudoString := ""
-	if shouldSudo {
-		sudoString = "sudo "
-	}
+func configureConsole(expecter expect.Expecter) error {
 	batch := []expect.Batcher{
 		&expect.BSnd{S: "stty cols 500 rows 500\n"},
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: RetValue("0")},
-		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
+		&expect.BSnd{S: "dmesg -n 1\n"},
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: RetValue("0")},

--- a/pkg/internal/checkup/executor/console/login.go
+++ b/pkg/internal/checkup/executor/console/login.go
@@ -87,8 +87,6 @@ func (e Expecter) LoginToCentOS(username, password string) error {
 				T: expect.OK(),
 			},
 		}},
-		&expect.BSnd{S: "sudo su\n"},
-		&expect.BExp{R: PromptExpression},
 	}
 	const loginTimeout = 2 * time.Minute
 	res, err := genExpect.ExpectBatch(b, loginTimeout)

--- a/pkg/internal/checkup/executor/console/login.go
+++ b/pkg/internal/checkup/executor/console/login.go
@@ -48,7 +48,7 @@ func (e Expecter) LoginToCentOS(username, password string) error {
 
 	// Do not login, if we already logged in
 	loggedInPromptRegex := fmt.Sprintf(
-		`(\[%s@(localhost|centos|%s) ~\]\$ |\[root@(localhost|centos|%s) centos\]\# )`, username, e.vmiName, e.vmiName,
+		`(\[%s@(localhost|centos|%s) ~\]\$ |\[root@(localhost|centos|%s) ~\]\# )`, username, e.vmiName, e.vmiName,
 	)
 	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -40,7 +40,6 @@ type vmiSerialConsoleClient interface {
 type Executor struct {
 	vmiSerialClient vmiSerialConsoleClient
 	namespace       string
-	vmiUsername     string
 	vmiPassword     string
 	OslatDuration   time.Duration
 }
@@ -49,7 +48,6 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 	return Executor{
 		vmiSerialClient: client,
 		namespace:       namespace,
-		vmiUsername:     config.VMIUsername,
 		vmiPassword:     config.VMIPassword,
 		OslatDuration:   cfg.OslatDuration,
 	}
@@ -58,7 +56,7 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 func (e Executor) Execute(ctx context.Context, vmiUnderTestName string) (status.Results, error) {
 	log.Printf("Login to VMI under test...")
 	vmiUnderTestConsoleExpecter := console.NewExpecter(e.vmiSerialClient, e.namespace, vmiUnderTestName)
-	if err := vmiUnderTestConsoleExpecter.LoginToCentOS(e.vmiUsername, e.vmiPassword); err != nil {
+	if err := vmiUnderTestConsoleExpecter.LoginToCentOSAsRoot(e.vmiPassword); err != nil {
 		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, vmiUnderTestName, err)
 	}
 

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -35,8 +35,8 @@ const (
 )
 
 const (
-	VMIUsername = "cloud-user"
-	VMIPassword = "0tli-pxem-xknu" // #nosec
+	VMIUsername = "root"
+	VMIPassword = "redhat" // #nosec
 
 	VMUnderTestDefaultContainerDiskImage = "quay.io/kiagnose/kubevirt-realtime-checkup-vm:main"
 	OslatDefaultDuration                 = 5 * time.Minute

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -35,7 +35,6 @@ const (
 )
 
 const (
-	VMIUsername = "root"
 	VMIPassword = "redhat" // #nosec
 
 	VMUnderTestDefaultContainerDiskImage = "quay.io/kiagnose/kubevirt-realtime-checkup-vm:main"


### PR DESCRIPTION
Currently, the checkup creates a `cloud-user` user using cloud-init, and logs in to the VM using its credentials.
Immediately after logging in, the checkup issues the `sudo su` command, thus effectively running as the root user.

Logging in as root simplifies the login operation, and remove problems that can occur when certain assumptions are made when performing the `sudo su` step - for example:
1. Not expecting the sudo warning message
2. Not expecting to enter the user's password again.

Also remove the creation of `cloud-user` volume, since it is no longer needed.

Based on work done in https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/225.