### PR TITLE
Add VM under test ConfigMap

### DIFF
--- a/pkg/internal/checkup/configmap/configmap.go
+++ b/pkg/internal/checkup/configmap/configmap.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package configmap
+
+import (
+	k8scorev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func New(name, ownerName, ownerUID string) *k8scorev1.ConfigMap {
+	return &k8scorev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       ownerName,
+					UID:        types.UID(ownerUID),
+				},
+			},
+		},
+	}
+}

--- a/pkg/internal/checkup/configmap/configmap_test.go
+++ b/pkg/internal/checkup/configmap/configmap_test.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package configmap_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	k8scorev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kiagnose/kubevirt-realtime-checkup/pkg/internal/checkup/configmap"
+)
+
+func TestNew(t *testing.T) {
+	name := "my-cm"
+	ownerName := "my-pod"
+	ownerUID := "1234567890"
+
+	actualConfigMap := configmap.New(name, ownerName, ownerUID)
+
+	expectedConfigMap := &k8scorev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       ownerName,
+					UID:        types.UID(ownerUID),
+				},
+			},
+		},
+		Data: nil,
+	}
+
+	assert.Equal(t, expectedConfigMap, actualConfigMap)
+}

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"time"
 
+	k8scorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
@@ -67,4 +68,8 @@ func (c *Client) VMISerialConsole(namespace, name string, timeout time.Duration)
 		name,
 		&kubecli.SerialConsoleOptions{ConnectionTimeout: timeout},
 	)
+}
+
+func (c *Client) CreateConfigMap(ctx context.Context, namespace string, configMap *k8scorev1.ConfigMap) (*k8scorev1.ConfigMap, error) {
+	return c.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
 }

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -73,3 +73,7 @@ func (c *Client) VMISerialConsole(namespace, name string, timeout time.Duration)
 func (c *Client) CreateConfigMap(ctx context.Context, namespace string, configMap *k8scorev1.ConfigMap) (*k8scorev1.ConfigMap, error) {
 	return c.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
 }
+
+func (c *Client) DeleteConfigMap(ctx context.Context, namespace, name string) error {
+	return c.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -259,6 +259,11 @@ func newKubeVirtRealTimeCheckerRole() *rbacv1.Role {
 				Resources: []string{"virtualmachineinstances/console"},
 				Verbs:     []string{"get"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"create", "delete"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
In order to enable the checkup the ability to create a ConfigMap containing a boot script to be attached to the VM under test, allow the checkup to create and delete a ConfigMap object.

Currently, the ConfigMap is empty and not attached to the VM under test.
Follow-up PRs will fill up the ConfigMap with a boot script and will attach it to the VM under test.

Currently, the ConfigMap name is not randomized.
A follow-up PR will add a random suffix to the ConfigMap's name.

Based on work done in https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/141.
~~Depends on https://github.com/kiagnose/kubevirt-realtime-checkup/pull/58, please review only the last five commits.~~