### PR TITLE
checkup: Mount configmap to the Realtime VMI

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -249,7 +249,6 @@ func newRealtimeVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstanc
 		vmi.WithoutAutoAttachGraphicsDevice(),
 		vmi.WithoutAutoAttachMemBalloon(),
 		vmi.WithAutoAttachSerialConsole(),
-		vmi.AutoIOThreadPolicy(),
 		vmi.WithZeroTerminationGracePeriodSeconds(),
 		vmi.WithNodeSelector(checkupConfig.VMUnderTestTargetNodeName),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.VMUnderTestContainerDiskImage),

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -142,12 +142,6 @@ func WithAutoAttachSerialConsole() Option {
 	}
 }
 
-func AutoIOThreadPolicy() Option {
-	return func(vmi *kvcorev1.VirtualMachineInstance) {
-		vmi.Spec.Domain.IOThreadsPolicy = Pointer(kvcorev1.IOThreadsPolicyAuto)
-	}
-}
-
 func WithVirtIODisk(name string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, kvcorev1.Disk{


### PR DESCRIPTION
This PR mounts the realtime configmap to the realtime VMI. 
The configmap is mounted to the VMI spec, then the Data on the configmap is mounted via cloudinit boot script.

The configmap currently has no data.