### PR TITLE
checkup, test: Remove unused const

### DIFF
--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -42,7 +42,6 @@ import (
 const (
 	testNamespace      = "target-ns"
 	testTargetNodeName = "my-node"
-	testPVCName        = "my-rt-vm-pvc"
 )
 
 func TestCheckupShouldSucceed(t *testing.T) {


### PR DESCRIPTION
This is a leftover from the days before container disk image was used.