### PR TITLE
Make VM image mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ roleRef:
 
 ## Configuration
 
-| Key                                          | Description                                                     | Is Mandatory | Remarks                                                          |
-|----------------------------------------------|-----------------------------------------------------------------|--------------|------------------------------------------------------------------|
-| spec.timeout                                 | How much time before the checkup will try to close itself       | True         |                                                                  |
-| spec.param.vmUnderTestContainerDiskImage     | VM under test container disk image                              | False        | Defaults to `quay.io/kiagnose/kubevirt-realtime-checkup-vm:main` |
-| spec.param.vmUnderTestTargetNodeName         | Node Name on which the VM under test will be scheduled to       | False        | Assumed to be configured to nodes that allow realtime traffic    |
-| spec.param.oslatDuration                     | How much time will the oslat program run                        | False        | Defaults to TBD                                                  |
-| spec.param.oslatLatencyThresholdMicroSeconds | A latency higher than this value will cause the checkup to fail | False        | Defaults to TBD                                                  |
+| Key                                          | Description                                                     | Is Mandatory | Remarks                                                       |
+|----------------------------------------------|-----------------------------------------------------------------|--------------|---------------------------------------------------------------|
+| spec.timeout                                 | How much time before the checkup will try to close itself       | True         |                                                               |
+| spec.param.vmUnderTestContainerDiskImage     | VM under test container disk image                              | True         |                                                               |
+| spec.param.vmUnderTestTargetNodeName         | Node Name on which the VM under test will be scheduled to       | False        | Assumed to be configured to nodes that allow realtime traffic |
+| spec.param.oslatDuration                     | How much time will the oslat program run                        | False        | Defaults to TBD                                               |
+| spec.param.oslatLatencyThresholdMicroSeconds | A latency higher than this value will cause the checkup to fail | False        | Defaults to TBD                                               |
 
 ### Example
 
@@ -82,6 +82,7 @@ metadata:
   name: realtime-checkup-config
 data:
   spec.timeout: 10m
+  spec.param.vmUnderTestContainerDiskImage: quay.io/kiagnose/kubevirt-realtime-checkup-vm:main
   spec.param.oslatDuration: 1h
 ```
 

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -37,9 +37,8 @@ const (
 const (
 	VMIPassword = "redhat" // #nosec
 
-	VMUnderTestDefaultContainerDiskImage = "quay.io/kiagnose/kubevirt-realtime-checkup-vm:main"
-	OslatDefaultDuration                 = 5 * time.Minute
-	OslatDefaultLatencyThreshold         = 40 * time.Microsecond
+	OslatDefaultDuration         = 5 * time.Minute
+	OslatDefaultLatencyThreshold = 40 * time.Microsecond
 
 	BootScriptName                          = "realtime-checkup-boot.sh"
 	BootScriptBinDirectory                  = "/usr/bin/"
@@ -48,6 +47,7 @@ const (
 )
 
 var (
+	ErrInvalidVMContainerDiskImage  = errors.New("invalid VM container disk image")
 	ErrInvalidOslatDuration         = errors.New("invalid oslat duration")
 	ErrInvalidOslatLatencyThreshold = errors.New("invalid oslat latency threshold")
 )
@@ -66,13 +66,13 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		PodName:                       baseConfig.PodName,
 		PodUID:                        baseConfig.PodUID,
 		VMUnderTestTargetNodeName:     baseConfig.Params[VMUnderTestTargetNodeNameParamName],
-		VMUnderTestContainerDiskImage: VMUnderTestDefaultContainerDiskImage,
+		VMUnderTestContainerDiskImage: baseConfig.Params[VMUnderTestContainerDiskImageParamName],
 		OslatDuration:                 OslatDefaultDuration,
 		OslatLatencyThreshold:         OslatDefaultLatencyThreshold,
 	}
 
-	if rawVal := baseConfig.Params[VMUnderTestContainerDiskImageParamName]; rawVal != "" {
-		newConfig.VMUnderTestContainerDiskImage = rawVal
+	if newConfig.VMUnderTestContainerDiskImage == "" {
+		return Config{}, ErrInvalidVMContainerDiskImage
 	}
 
 	if rawOslatDuration := baseConfig.Params[OslatDurationParamName]; rawOslatDuration != "" {

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -43,7 +43,9 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 	baseConfig := kconfig.Config{
 		PodName: testPodName,
 		PodUID:  testPodUID,
-		Params:  map[string]string{},
+		Params: map[string]string{
+			config.VMUnderTestContainerDiskImageParamName: testVMContainerDiskImage,
+		},
 	}
 
 	actualConfig, err := config.New(baseConfig)
@@ -53,7 +55,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		PodName:                       testPodName,
 		PodUID:                        testPodUID,
 		VMUnderTestTargetNodeName:     "",
-		VMUnderTestContainerDiskImage: config.VMUnderTestDefaultContainerDiskImage,
+		VMUnderTestContainerDiskImage: testVMContainerDiskImage,
 		OslatDuration:                 config.OslatDefaultDuration,
 		OslatLatencyThreshold:         config.OslatDefaultLatencyThreshold,
 	}
@@ -95,20 +97,27 @@ func TestNewShouldFailWhen(t *testing.T) {
 
 	testCases := []failureTestCase{
 		{
+			description:    "VM container disk image is missing",
+			userParameters: map[string]string{},
+			expectedError:  config.ErrInvalidVMContainerDiskImage,
+		},
+		{
 			description: "oslatDuration is invalid",
 			userParameters: map[string]string{
-				config.VMUnderTestTargetNodeNameParamName: testVMUnderTestTargetNodeName,
-				config.OslatDurationParamName:             "wrongValue",
-				config.OslatLatencyThresholdParamName:     testOslatLatencyThresholdMicroSeconds,
+				config.VMUnderTestContainerDiskImageParamName: testVMContainerDiskImage,
+				config.VMUnderTestTargetNodeNameParamName:     testVMUnderTestTargetNodeName,
+				config.OslatDurationParamName:                 "wrongValue",
+				config.OslatLatencyThresholdParamName:         testOslatLatencyThresholdMicroSeconds,
 			},
 			expectedError: config.ErrInvalidOslatDuration,
 		},
 		{
 			description: "oslatLatencyThresholdMicroSeconds is invalid",
 			userParameters: map[string]string{
-				config.VMUnderTestTargetNodeNameParamName: testVMUnderTestTargetNodeName,
-				config.OslatDurationParamName:             testOslatDuration,
-				config.OslatLatencyThresholdParamName:     "wrongValue",
+				config.VMUnderTestContainerDiskImageParamName: testVMContainerDiskImage,
+				config.VMUnderTestTargetNodeNameParamName:     testVMUnderTestTargetNodeName,
+				config.OslatDurationParamName:                 testOslatDuration,
+				config.OslatLatencyThresholdParamName:         "wrongValue",
 			},
 			expectedError: config.ErrInvalidOslatLatencyThreshold,
 		},


### PR DESCRIPTION
Currently, vmUnderTestContainerDiskImage defaults to: `quay.io/kiagnose/kubevirt-realtime-checkup-vm:main`.

This may lead to unexpected behavior when using an older checkup version in combination with the latest VM container disk image (tagged as `main`).

Make the field mandatory in order for the user to specify it explicitly.