### PR TITLE
Upgrade container disk image to CentOS Stream 9

### DIFF
--- a/pkg/internal/checkup/executor/console/login.go
+++ b/pkg/internal/checkup/executor/console/login.go
@@ -106,7 +106,7 @@ func (e Expecter) LoginToCentOSAsRoot(password string) error {
 
 func configureConsole(expecter expect.Expecter) error {
 	batch := []expect.Batcher{
-		&expect.BSnd{S: "stty cols 500 rows 500\n"},
+		&expect.BSnd{S: "stty cols 160 rows 50\n"},
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: RetValue("0")},

--- a/vms/vm-under-test/scripts/build-vm-image
+++ b/vms/vm-under-test/scripts/build-vm-image
@@ -19,10 +19,10 @@
 
 export LIBGUESTFS_BACKEND=direct
 
-virt-builder centosstream-8 \
+virt-builder centosstream-9 \
   --format qcow2 \
   --root-password password:redhat \
-  --install cloud-init,kernel-rt,tuned,rt-tests \
+  --install cloud-init,tuned,realtime-tests \
   --run /root/scripts/customize-vm \
   --selinux-relabel \
   --output /output/kubevirt-realtime-checkup-vm.qcow2

--- a/vms/vm-under-test/scripts/customize-vm
+++ b/vms/vm-under-test/scripts/customize-vm
@@ -29,7 +29,7 @@ disable_services() {
 
 # Install required packages
 install_packages() {
-  dnf --enablerepo=rt install -y tuned-profiles-realtime
+  dnf --enablerepo=rt install -y kernel-rt tuned-profiles-realtime
   dnf --enablerepo=nfv install -y tuned-profiles-nfv-guest
 }
 
@@ -45,7 +45,12 @@ enable_guest_exec() {
   sed -i '/^BLACKLIST_RPC=/ { s/,\+/,/g; s/^,\|,$//g }' /etc/sysconfig/qemu-ga
 }
 
+disable_bracketed_paste() {
+  echo "set enable-bracketed-paste off" >> /root/.inputrc
+}
+
 disable_services
 install_packages
 disable_swap
 enable_guest_exec
+disable_bracketed_paste


### PR DESCRIPTION
CentOS stream 8 had reached EOL [1] and it breaks our automation for
building the container disk image due to [2].

Our console package does not correctly handle Bracketed-paste [3],
disable it for now.

On CentOS stream 9 it is required to enable the `rt` repo in order to install a real-time kernel.

The real-time tests package name was changed.

Fixes #70.

[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

[2] https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve

[3] https://en.wikipedia.org/wiki/Bracketed-paste