### PR TITLE
Dockerfile: Bump base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1612
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194
 
 RUN microdnf install -y shadow-utils && \
     adduser --system --no-create-home -u 900 rt-checkup && \


### PR DESCRIPTION
Bump base image version to:
`registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194`.