### PR TITLE
Bump Go version to 1.22.5

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.20.12
 
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
-LINTER_IMAGE_TAG := v1.50.1
+LINTER_IMAGE_TAG := v1.60.1
 KUBECONFIG ?= $(HOME)/.kube/config
 
 PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-realtime-checkup

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ VM_CONTAINER_DISK_IMAGE_NAME := kubevirt-realtime-checkup-vm
 VM_CONTAINER_DISK_IMAGE_TAG ?= latest
 
 GO_IMAGE_NAME := docker.io/library/golang
-GO_IMAGE_TAG := 1.20.12
+GO_IMAGE_TAG := 1.22.5
 
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
 LINTER_IMAGE_TAG := v1.60.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiagnose/kubevirt-realtime-checkup
 
-go 1.20
+go 1.22.0
 
 require (
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f


### PR DESCRIPTION
Additionally, bump the linter version in order for it to support the new Go version.